### PR TITLE
Changes related to the next MeiliSearch release (v0.21.0)

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -1,0 +1,27 @@
+name-template: 'v$RESOLVED_VERSION 🛤'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  default: patch
+categories:
+  - title: 'Breaking changes ⚠️'
+    label: 'breaking-change'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  Thanks again to $CONTRIBUTORS! 🎉
+no-changes-template: 'Changes are coming soon 😎'
+sort-direction: 'ascending'
+replacers:
+  - search: '/(?:and )?@dependabot(?:\[bot\])?,?/g'
+    replace: ''
+  - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
+    replace: ''
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-draft-template.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '~> 2.5', '>= 2.5.1'
-gem 'meilisearch', '~> 0.15.3'
+gem 'meilisearch', '~> 0.16.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ end
 
 #### Backend Pagination <!-- omit in toc -->
 
-We support both [kaminari](https://github.com/amatsuda/kaminari) and [will_paginate](https://github.com/mislav/will_paginate).
+This gem supports:
+- [kaminari](https://github.com/amatsuda/kaminari)
+- [pagy](https://github.com/ddnexus/pagy)
+- [will_paginate](https://github.com/mislav/will_paginate).
 
 Specify the `:pagination_backend` in the configuration file:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To learn more about MeiliSearch, check out our [Documentation](https://docs.meil
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.20.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.20.0).
+This package only guarantees the compatibility with the [version v0.21.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.21.0).
 
 ## 🔧 Installation
 


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/117

This PR:
- gathers the changes related to the next MeiliSearch release (v0.21.0) so that this package is ready when the official release is out.
- might eventually contain test failures until the MeiliSearch v0.21.0 is out.

⚠️ This PR should NOT be merged until the next release of MeiliSearch (v0.21.0) is out.

Done:
- Changes related to v0.21.0 #58 #59
    - Rename `Filters` into `Filter`
    - Rename `attributes_for_faceting` into `filterable_attributes`
    - Fix tests
    - Add missing tests according to new features