### PR TITLE
Fix Ruby syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ class Book < ApplicationRecord
     synonyms nyc: ['new york']
 
     # The following parameters are applied when calling the search() method:
-    attributesToHighlight ["*"]
+    attributesToHighlight ['*']
     attributesToCrop [:description]
     cropLength 10
   end

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ class Book < ApplicationRecord
       'exactness',
       'desc(publication_year)'
     ]
-    synonyms nyc: ["new york"]
+    synonyms nyc: ['new york']
 
     # The following parameters are applied when calling the search() method:
     attributesToHighlight ["*"]

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ end
 
 You can add a custom attribute by using the `add_attribute` option or by using a block.
 
-⚠️ When using custom attributes, the gem is not able to detect changes on them. Your record will be pushed to the API even if the custom attribute didn’t change. To prevent this behavior, you can create a `will_save_change_to_#{attr_name}?` method.
+⚠️ When using custom attributes, the gem is not able to detect changes on them. Your record will be pushed to the API even if the custom attribute didn't change. To prevent this behavior, you can create a `will_save_change_to_#{attr_name}?` method.
 
 ```ruby
 class Author < ApplicationRecord

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ end
 
 #### Share a single index
 
-You may want to share an index between several models. You’ll need to ensure you don’t have any conflict with the `primary_key` of the models involved.
+You may want to share an index between several models. You'll need to ensure you don't have any conflict with the `primary_key` of the models involved.
 
 ```ruby
 class Cat < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ end
 
 #### Custom primary key
 
-By default, the primary key is based on your record’s id. You can change this behavior specifying the `primary_key:` option.
+By default, the primary key is based on your record's id. You can change this behavior by specifying the `primary_key:` option.
 
 Note that the primary key must have a **unique value**.
 

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ class Book < ApplicationRecord
     searchableAttributes [:title, :author, :publisher, :description]
     attributesForFaceting [:genre]
     rankingRules [
-      "proximity",
-      "typo",
-      "words",
-      "attribute",
-      "wordsPosition",
-      "exactness",
-      "desc(publication_year)"
+      'proximity',
+      'typo',
+      'words',
+      'attribute',
+      'wordsPosition',
+      'exactness',
+      'desc(publication_year)'
     ]
     synonyms nyc: ["new york"]
 


### PR DESCRIPTION
Hey there! Thanks for maintaining meilisearch-rails!

Here are some fixes to the Ruby code examples in the README, as well as some minor reformatting to make examples more consistent between each other and feel more Ruby-esque.