### PR TITLE
Accept snake_case for meilisearch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ class Book < ApplicationRecord
   include MeiliSearch
 
   meilisearch do
-    searchableAttributes ['title', 'author', 'publisher', 'description']
-    attributesForFaceting ['genre']
-    rankingRules [
+    searchable_attributes ['title', 'author', 'publisher', 'description']
+    attributes_for_faceting ['genre']
+    ranking_rules [
         "proximity",
         "typo",
         "words",
@@ -204,10 +204,10 @@ class Book < ApplicationRecord
         "desc(publication_year)"
     ]
     synonyms nyc: ['new york']
-    // The following parameters are applied when calling the search() method:
-    attributesToHighlight ['*']
-    attributesToCrop ['description']
-    cropLength 10
+    # The following parameters are applied when calling the search() method:
+    attributes_to_highlight ['*']
+    attributes_to_crop ['description']
+    crop_length 10
   end
 end
 ```
@@ -221,7 +221,8 @@ All the supported options are described in the [search parameters](https://docs.
 ```ruby
 Book.search('Harry', { filters: 'author = J. K. Rowling' })
 ```
-👉 Don't forget that `attributesToHighlight`, `attributesToCrop`, and `cropLength` can be set up in the `meilisearch` block of your model.
+👉 Don't forget that `attributes_to_highlight`, `attributes_to_crop`, and
+`crop_length` can be set up in the `meilisearch` block of your model.
 
 ## 🪛 Options
 
@@ -337,11 +338,11 @@ class Book < ActiveRecord::Base
 
   # store all books in index 'SECURED_INDEX_UID'
   meilisearch index_uid: SECURED_INDEX_UID do
-    searchableAttributes [:title, :author]
+    searchable_attributes [:title, :author]
 
     # store all 'public' (released and not premium) books in index 'PUBLIC_INDEX_UID'
     add_index PUBLIC_INDEX_UID, if: :public? do
-      searchableAttributes [:title, :author]
+      searchable_attributes [:title, :author]
     end
   end
 

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -52,16 +52,25 @@ module MeiliSearch
 
     # MeiliSearch settings
     OPTIONS = [
-      :searchableAttributes, :attributesForFaceting, :displayedAttributes, :distinctAttribute,
-      :synonyms, :stopWords, :rankingRules,
+      :searchableAttributes,
+      :attributesForFaceting,
+      :displayedAttributes,
+      :distinctAttribute,
+      :synonyms,
+      :stopWords,
+      :rankingRules,
       :attributesToHighlight,
-      :attributesToCrop, :cropLength
+      :attributesToCrop,
+      :cropLength,
     ]
 
-    OPTIONS.each do |k|
-      define_method k do |v|
-        instance_variable_set("@#{k}", v)
+    OPTIONS.each do |option|
+      define_method option do |value|
+        instance_variable_set("@#{option}", value)
       end
+
+      underscored_name = option.to_s.gsub(/(.)([A-Z])/, '\1_\2').downcase
+      alias_method underscored_name, option if underscored_name != option
     end
 
     def initialize(options, &block)

--- a/playground/app/models/book.rb
+++ b/playground/app/models/book.rb
@@ -6,13 +6,13 @@ class Book < ApplicationRecord
     searchable_attributes [:title, :author, :publisher, :description]
     attributes_for_faceting [:genre]
     ranking_rules [
-      "proximity",
-      "typo",
-      "words",
-      "attribute",
-      "wordsPosition",
-      "exactness",
-      "desc(publication_year)",
+      'proximity',
+      'typo',
+      'words',
+      'attribute',
+      'wordsPosition',
+      'exactness',
+      'desc(publication_year)',
     ]
     attributes_to_highlight ['*']
     attributes_to_crop [:description]

--- a/playground/app/models/book.rb
+++ b/playground/app/models/book.rb
@@ -1,26 +1,26 @@
 class Book < ApplicationRecord
-    include MeiliSearch
+  include MeiliSearch
 
-    meilisearch do
-        # add_attribute :extra_attr
-        searchableAttributes ['title', 'author', 'publisher', 'description']
-        attributesForFaceting ['genre']
-        rankingRules [
-            "proximity",
-            "typo",
-            "words",
-            "attribute",
-            "wordsPosition",
-            "exactness",
-            "desc(publication_year)"
-        ]
-        attributesToHighlight ['*']
-        attributesToCrop ['description']
-        cropLength 10
-        synonyms man: ['life']
-    end
+  meilisearch do
+    # add_attribute :extra_attr
+    searchable_attributes [:title, :author, :publisher, :description]
+    attributes_for_faceting [:genre]
+    ranking_rules [
+      "proximity",
+      "typo",
+      "words",
+      "attribute",
+      "wordsPosition",
+      "exactness",
+      "desc(publication_year)",
+    ]
+    attributes_to_highlight ['*']
+    attributes_to_crop [:description]
+    crop_length 10
+    synonyms man: ['life']
+  end
 
-    # def extra_attr
-    #     "extra_val"
-    # end
+  # def extra_attr
+  #   "extra_val"
+  # end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -172,8 +172,8 @@ end
 class Restaurant < ActiveRecord::Base
   include MeiliSearch
   meilisearch index_uid: safe_index_uid("Restaurant")do
-    attributesToCrop [:description]
-    cropLength 10
+    attributes_to_crop [:description]
+    crop_length 10
   end
 end
 
@@ -233,10 +233,10 @@ class Song < ActiveRecord::Base
   SECURED_INDEX_UID = safe_index_uid('PrivateSongs')
 
   meilisearch index_uid: SECURED_INDEX_UID do
-    searchableAttributes [:name, :artist]
+    searchable_attributes [:name, :artist]
 
     add_index PUBLIC_INDEX_UID, if: :public? do
-      searchableAttributes [:name, :artist]
+      searchable_attributes [:name, :artist]
     end
   end
 
@@ -269,10 +269,18 @@ class Color < ActiveRecord::Base
   attr_accessor :not_indexed
 
   meilisearch synchronous: true, index_uid: safe_index_uid("Color"), per_environment: true do
-    searchableAttributes [:name]
-    attributesForFaceting ['short_name']
-    rankingRules ['typo', 'words', 'proximity', 'attribute', 'wordsPosition', 'exactness','asc(hex)']
-    attributesToHighlight [:name]
+    searchable_attributes [:name]
+    attributes_for_faceting ['short_name']
+    ranking_rules [
+      'typo',
+      'words',
+      'proximity',
+      'attribute',
+      'wordsPosition',
+      'exactness',
+      'asc(hex)',
+    ]
+    attributes_to_highlight [:name]
   end
 
   def will_save_change_to_hex?
@@ -324,7 +332,7 @@ class Namespaced::Model < ActiveRecord::Base
     attribute :myid do
       id
     end
-    searchableAttributes ['customAttr']
+    searchable_attributes ['customAttr']
   end
 end
 
@@ -373,7 +381,7 @@ class SequelBook < Sequel::Model(SEQUEL_DB)
     add_attribute :test
     add_attribute :test2
 
-    searchableAttributes [:name]
+    searchable_attributes [:name]
   end
 
   def after_create
@@ -433,14 +441,14 @@ class Book < ActiveRecord::Base
   include MeiliSearch
 
   meilisearch synchronous: true, index_uid: safe_index_uid("SecuredBook"), per_environment: true, sanitize: true do
-    searchableAttributes [:name]
+    searchable_attributes [:name]
 
     add_index safe_index_uid('BookAuthor'), per_environment: true do
-      searchableAttributes [:author]
+      searchable_attributes [:author]
     end
 
     add_index safe_index_uid('Book'), per_environment: true, if: :public? do
-      searchableAttributes [:name]
+      searchable_attributes [:name]
     end
   end
 
@@ -455,7 +463,7 @@ class Ebook < ActiveRecord::Base
   attr_accessor :current_time, :published_at
 
   meilisearch synchronous: true, index_uid: safe_index_uid("eBooks")do
-    searchableAttributes [:name]
+    searchable_attributes [:name]
   end
 
   def ms_dirty?
@@ -1146,7 +1154,7 @@ describe 'Will_paginate' do
   end
 end
 
-describe "attributesToCrop" do
+describe "attributes_to_crop" do
   before(:all) do
     MeiliSearch.configuration = { meilisearch_host: ENV['MEILISEARCH_HOST'], meilisearch_api_key: ENV['MEILISEARCH_API_KEY']}
     10.times do
@@ -1323,4 +1331,3 @@ describe "Raise on failure" do
     end.not_to raise_error
   end
 end
-

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1154,7 +1154,7 @@ describe 'Will_paginate' do
   end
 end
 
-describe "attributes_to_crop" do
+describe 'attributes_to_crop' do
   before(:all) do
     MeiliSearch.configuration = { meilisearch_host: ENV['MEILISEARCH_HOST'], meilisearch_api_key: ENV['MEILISEARCH_API_KEY']}
     10.times do


### PR DESCRIPTION
In order to be more Ruby-esque, this uses snake_case options in favor of the camelCase options.

The camelCase syntax is kept for backwards compatibility.