### PR TITLE
Add timeout and max_retries options

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ Create a new file `config/initializers/meilisearch.rb` to setup your `MEILISEARC
 MeiliSearch.configuration = {
   meilisearch_host: 'YourMeiliSearchHost',
   meilisearch_api_key: 'YourMeiliSearchAPIKey',
-
-  # Extra configuration:
-  # timeout: 2,
-  # max_retries: 1,
 }
 ```
 
@@ -187,7 +183,21 @@ The **number of hits per page defaults to 20**, you can customize it by adding t
 Book.search('harry potter', hitsPerPage: 10)
 ```
 
-##  ⚙️ Settings
+#### Extra Configuration <!-- omit in toc -->
+
+Requests made to MeiliSearch may timeout and retry. To adapt the behavior to
+your needs, you can change the parameters during configuration:
+
+```ruby
+MeiliSearch.configuration = {
+  meilisearch_host: 'YourMeiliSearchHost',
+  meilisearch_api_key: 'YourMeiliSearchAPIKey',
+  timeout: 2,
+  max_retries: 1,
+}
+```
+
+## ⚙️ Settings
 
 You can configure the index settings by adding them inside the `meilisearch` block as shown below:
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,12 @@ Create a new file `config/initializers/meilisearch.rb` to setup your `MEILISEARC
 
 ```ruby
 MeiliSearch.configuration = {
-    meilisearch_host: 'YourMeiliSearchHost',
-    meilisearch_api_key: 'YourMeiliSearchAPIKey',
+  meilisearch_host: 'YourMeiliSearchHost',
+  meilisearch_api_key: 'YourMeiliSearchAPIKey',
+
+  # Extra configuration:
+  # timeout: 2,
+  # max_retries: 1,
 }
 ```
 

--- a/lib/meilisearch/configuration.rb
+++ b/lib/meilisearch/configuration.rb
@@ -9,7 +9,11 @@ module MeiliSearch
     end
 
     def client
-      ::MeiliSearch::Client.new(@@configuration[:meilisearch_host], @@configuration[:meilisearch_api_key])
+      ::MeiliSearch::Client.new(
+        configuration[:meilisearch_host],
+        configuration[:meilisearch_api_key],
+        **configuration.slice(:timeout, :max_retries)
+      )
     end
   end
 end

--- a/lib/meilisearch/configuration.rb
+++ b/lib/meilisearch/configuration.rb
@@ -12,7 +12,7 @@ module MeiliSearch
       ::MeiliSearch::Client.new(
         configuration[:meilisearch_host],
         configuration[:meilisearch_api_key],
-        **configuration.slice(:timeout, :max_retries)
+        configuration.slice(:timeout, :max_retries)
       )
     end
   end

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.summary = "MeiliSearch integration for Ruby on Rails."
-  s.add_dependency(%q<json>, [">= 1.5.1"])
-  s.add_dependency(%q<meilisearch>, [">= 0.15.3"])
+  s.add_dependency("json", [">= 1.5.1"])
+  s.add_dependency("meilisearch", [">= 0.15.4"])
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,59 @@
+require File.expand_path(File.join(__dir__, "spec_helper"))
+
+MeiliSearch.configuration = {
+  meilisearch_host: ENV['MEILISEARCH_HOST'],
+  meilisearch_api_key: ENV['MEILISEARCH_API_KEY'],
+}
+
+describe MeiliSearch::Configuration do
+  let(:configuration) {
+    {
+      meilisearch_host: "http://localhost:7700",
+      meilisearch_api_key: "s3cr3tap1k3y",
+    }
+  }
+
+  before do
+    allow(MeiliSearch).to receive(:configuration) { configuration }
+  end
+
+  describe ".client" do
+    let(:client_double) { double MeiliSearch::Client }
+
+    before do
+      allow(MeiliSearch::Client).to receive(:new) { client_double }
+    end
+
+    it "initializes a MeiliSearch::Client" do
+      expect(MeiliSearch.client).to eq(client_double)
+
+      expect(MeiliSearch::Client)
+        .to have_received(:new)
+        .with("http://localhost:7700", "s3cr3tap1k3y")
+    end
+
+    context "with timeout and max retries" do
+      let(:configuration) {
+        {
+          meilisearch_host: "http://localhost:7700",
+          meilisearch_api_key: "s3cr3tap1k3y",
+          timeout: 2,
+          max_retries: 1,
+        }
+      }
+
+      it "forwards them to the client" do
+        expect(MeiliSearch.client).to eq(client_double)
+
+        expect(MeiliSearch::Client)
+          .to have_received(:new)
+          .with(
+            "http://localhost:7700",
+            "s3cr3tap1k3y",
+            timeout: 2,
+            max_retries: 1,
+          )
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -29,7 +29,7 @@ describe MeiliSearch::Configuration do
 
       expect(MeiliSearch::Client)
         .to have_received(:new)
-        .with("http://localhost:7700", "s3cr3tap1k3y")
+        .with("http://localhost:7700", "s3cr3tap1k3y", {})
     end
 
     context "with timeout and max retries" do


### PR DESCRIPTION
Add access to `timeout` and `max_retries` configuration options from Meilisearch’s HTTParty integration.