### PR TITLE
Fix undefined method in reindex_all_models

### DIFF
--- a/lib/meilisearch/utilities.rb
+++ b/lib/meilisearch/utilities.rb
@@ -26,7 +26,7 @@ module MeiliSearch
         klasses.each do |klass|
           puts klass
           puts "Reindexing #{klass.count} records..."
-          klass.ms_reindex
+          klass.ms_reindex!
         end
       end
 


### PR DESCRIPTION
This issue cause `rails meilisearch:reindex` task failed.

log
```
NoMethodError: undefined method `ms_reindex' for ProjectFile:Class
Did you mean?  ms_reindex!
               must_reindex?
               ms_index
               ms_index!
```