### PR TITLE
Update meilisearch_host in the conf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Create a new file `config/initializers/meilisearch.rb` to setup your `MEILISEARC
 
 ```ruby
 MeiliSearch.configuration = {
-  meilisearch_host: 'YourMeiliSearchHost',
+  meilisearch_host: 'http://YourMeiliSearchHost:7700',
   meilisearch_api_key: 'YourMeiliSearchAPIKey',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Create a new file `config/initializers/meilisearch.rb` to setup your `MEILISEARC
 
 ```ruby
 MeiliSearch.configuration = {
-  meilisearch_host: 'http://YourMeiliSearchHost:7700',
+  meilisearch_host: 'YourMeiliSearchHost', # example: http://localhost:7700
   meilisearch_api_key: 'YourMeiliSearchAPIKey',
 }
 ```


### PR DESCRIPTION
It could be confusing for some people trying to setup the gem to see `YourMeiliSearchHost` as is, without knowing if adding the port is mandatory or not. This PR proposes to update the `meilisearch_host` key in the example configuration to note that it must be an URI if the port has to be set.