### PR TITLE
Bump meilisearch-ruby (v0.18.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'json', '~> 2.5', '>= 2.5.1'
-gem 'meilisearch', '~> 0.17.0'
+gem 'meilisearch', '~> 0.18.0'
 
 gem 'rubysl', '~> 2.0', platform: :rbx if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ class Book < ActiveRecord::Base
   end
 end
 ```
-🚨 This is only recommended for testing purposes, the gem will call the `wait_for_pending_update` method that will stop your code execution until the asynchronous task has been processed by MeilSearch.
+🚨 This is only recommended for testing purposes, the gem will call the `wait_for_task` method that will stop your code execution until the asynchronous task has been processed by MeilSearch.
 
 ##### Disable auto-indexing & auto-removal <!-- omit in toc -->
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1268,7 +1268,7 @@ describe 'People' do
 
     expect do
       person.update(first_name: 'Jane')
-    end.to_not change(People.index.tasks['results'], :size)
+    end.not_to change(People.index.tasks['results'], :size)
   end
 
   it 'does not auto-remove' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1264,19 +1264,11 @@ describe 'People' do
   end
 
   it 'does not call the API if there has been no attribute change' do
-    person = People.search('Jane')[0]
-    before_save_statuses = People.index.tasks['results']
-    before_save_status = before_save_statuses.first
-    person.first_name = 'Jane'
-    person.save
-    after_save_statuses = People.index.tasks['results']
-    after_save_status = after_save_statuses.first
-    expect(before_save_status['uid']).to eq(after_save_status['uid'])
-    person.first_name = 'Alice'
-    person.save
-    after_change_statuses = People.index.tasks['results']
-    after_change_status = after_change_statuses.first
-    expect(before_save_status['uid']).not_to eq(after_change_status['uid'])
+    person = People.search('Jane').first
+
+    expect do
+      person.update(first_name: 'Jane')
+    end.to_not change(People.index.tasks['results'], :size)
   end
 
   it 'does not auto-remove' do


### PR DESCRIPTION
- Update meilisearch-ruby to v0.18.0
- Remove `get_or_create_index` method usage
- Changes regarding task API changes
