### PR TITLE
Fix Rails module calls inside the Meilisearch::Rails & Add smoke-test workflow step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,3 +48,23 @@ jobs:
       run: bundle install --with test
     - name: Run linter
       run: bundle exec rubocop lib/ spec/
+
+  smoke-test:
+    name: smoke-test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+      - name: Meilisearch (latest) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
+
+      - name: Install ruby dependencies
+        working-directory: ./playground
+        run: bundle install --without test
+
+      - name: Run smoke tests
+        working-directory: ./playground
+        run: bundle exec rake db:setup meilisearch:reindex meilisearch:clear_indexes

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,8 @@
 status = [
   'integration-tests (Rails 5.2)',
   'integration-tests (Rails 6.1)',
-  'linter-check'
+  'linter-check',
+  'smoke-test'
 ]
 # 1 hour timeout
 timeout-sec = 3600

--- a/lib/meilisearch/rails/railtie.rb
+++ b/lib/meilisearch/rails/railtie.rb
@@ -2,13 +2,13 @@ require 'rails'
 
 module MeiliSearch
   module Rails
-    class Railtie < Rails::Railtie
+    class Railtie < ::Rails::Railtie
       rake_tasks do
-        load 'meilisearch/tasks/meilisearch.rake'
+        load 'meilisearch/rails/tasks/meilisearch.rake'
       end
     end
 
-    class Engine < Rails::Engine
+    class Engine < ::Rails::Engine
     end
   end
 end

--- a/lib/meilisearch/rails/tasks/meilisearch.rake
+++ b/lib/meilisearch/rails/tasks/meilisearch.rake
@@ -1,17 +1,22 @@
 namespace :meilisearch do
   desc 'Reindex all models'
   task reindex: :environment do
+    puts 'Reindexing all Meilisearch models'
+
     MeiliSearch::Rails::Utilities.reindex_all_models
   end
 
   desc 'Set settings to all indexes'
   task set_all_settings: :environment do
+    puts 'Set settings in all Meilisearch models'
+
     MeiliSearch::Rails::Utilities.set_settings_all_models
   end
 
   desc 'Clear all indexes'
   task clear_indexes: :environment do
-    puts 'clearing all indexes'
+    puts 'Clearing indexes from all Meilisearch models'
+
     MeiliSearch::Rails::Utilities.clear_all_indexes
   end
 end

--- a/lib/meilisearch/rails/tasks/meilisearch.rake
+++ b/lib/meilisearch/rails/tasks/meilisearch.rake
@@ -1,17 +1,17 @@
 namespace :meilisearch do
   desc 'Reindex all models'
   task reindex: :environment do
-    MeiliSearch::Utilities.reindex_all_models
+    MeiliSearch::Rails::Utilities.reindex_all_models
   end
 
   desc 'Set settings to all indexes'
   task set_all_settings: :environment do
-    MeiliSearch::Utilities.set_settings_all_models
+    MeiliSearch::Rails::Utilities.set_settings_all_models
   end
 
   desc 'Clear all indexes'
   task clear_indexes: :environment do
     puts 'clearing all indexes'
-    MeiliSearch::Utilities.clear_all_indexes
+    MeiliSearch::Rails::Utilities.clear_all_indexes
   end
 end

--- a/playground/app/models/book.rb
+++ b/playground/app/models/book.rb
@@ -1,5 +1,5 @@
 class Book < ApplicationRecord
-  include MeiliSearch
+  include MeiliSearch::Rails
 
   meilisearch do
     # add_attribute :extra_attr

--- a/playground/config/initializers/meilisearch.rb
+++ b/playground/config/initializers/meilisearch.rb
@@ -1,5 +1,5 @@
 MeiliSearch::Rails.configuration = {
     meilisearch_host: 'http://127.0.0.1:7700',
-    meilisearch_api_key: '',
+    meilisearch_api_key: 'masterKey',
     pagination_backend: :kaminari #:will_paginate
 }

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rake'
 
 describe MeiliSearch::Rails::Utilities do
   around do |example|
@@ -12,5 +13,27 @@ describe MeiliSearch::Rails::Utilities do
 
   it 'gets the models where Meilisearch module was included' do
     expect(described_class.get_model_classes - [Dummy, DummyChild, DummyGrandChild]).to be_empty
+  end
+
+  context 'when invoked from rake task' do
+    before do
+      file = File.join('..', 'lib', 'meilisearch', 'rails', 'tasks', 'meilisearch')
+      Rake.application.rake_require file.to_s
+      Rake::Task.define_task(:environment)
+    end
+
+    {
+      reindex: :reindex_all_models,
+      set_all_settings: :set_settings_all_models,
+      clear_indexes: :clear_all_indexes
+    }.each do |task, method_name|
+      it "calls #{described_class}.#{method_name} successfully" do
+        allow(described_class).to receive(method_name).and_return(nil)
+
+        Rake.application.invoke_task "meilisearch:#{task}"
+
+        expect(described_class).to have_received(method_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
After defining the new Rails module to separate the logic between the meilisearch-ruby gem and this one
some `Rails` calls were incorrectly defined, they missed the `::` top-level reset to ignore the new `MeiliSearch::Rails` module.


Related to https://github.com/meilisearch/meilisearch-rails/issues/107
Fixes https://github.com/meilisearch/meilisearch-rails/issues/110