### PR TITLE
Integration test rubies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
             rails-version: 5.2
           - ruby-version: "3.1"
             rails-version: 5.2
+          - ruby-version: "2.6"
+            rails-version: 7.0
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     name: integration-tests (Rails ${{ matrix.rails-version }} with Ruby ${{ matrix.ruby-version }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails-version: [5.2, 6.1]
+        ruby-version: ["2.7", "3.0", "3.1"]
+        rails-version: [5.2, 6.1, 7.0]
+        exclude:
+          - ruby-version: "3.0"
+            rails-version: 5.2
+          - ruby-version: "3.1"
+            rails-version: 5.2
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     name: integration-tests (Rails ${{ matrix.rails-version }})
@@ -27,9 +33,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
     - name: Meilisearch (latest) setup with Docker
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         BUNDLE_WITH: test
       with:
         ruby-version: 2.6
-        bundler_cache: true
+        bundler-cache: true
     - name: Run linter
       run: bundle exec rubocop lib/ spec/
 
@@ -66,10 +66,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         env:
           BUNDLE_WITHOUT: test
+          BUNDLE_GEMFILE: ./playground/Gemfile
         with:
           ruby-version: 2.7.2
           bundler-cache: true
       - name: Meilisearch (latest) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
       - name: Run smoke tests
+        working-directory: ./playground
         run: bundle exec rake db:setup meilisearch:reindex meilisearch:clear_indexes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["2.6", "2.7", "3.0", "3.1"]
-        rails-version: [5.2, 6.1, 7.0]
+        rails-version: [4.2, 5.2, 6.1, 7.0]
         exclude:
+          - ruby-version: "3.0"
+            rails-version: 4.2
+          - ruby-version: "3.1"
+            rails-version: 4.2
           - ruby-version: "3.0"
             rails-version: 5.2
           - ruby-version: "3.1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_WITH: test
       with:
         ruby-version: 2.6
-    - name: Install ruby dependencies
-      run: bundle install --with test
+        bundler_cache: true
     - name: Run linter
       run: bundle exec rubocop lib/ spec/
 
@@ -61,15 +62,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+        working-directory: ./playground
+        env:
+          BUNDLE_WITHOUT: test
         with:
           ruby-version: 2.7.2
+          bundler-cache: true
       - name: Meilisearch (latest) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
-
-      - name: Install ruby dependencies
-        working-directory: ./playground
-        run: bundle install --without test
-
       - name: Run smoke tests
         working-directory: ./playground
         run: bundle exec rake db:setup meilisearch:reindex meilisearch:clear_indexes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        working-directory: ./playground
         env:
           BUNDLE_WITHOUT: test
         with:
@@ -71,5 +70,4 @@ jobs:
       - name: Meilisearch (latest) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
       - name: Run smoke tests
-        working-directory: ./playground
         run: bundle exec rake db:setup meilisearch:reindex meilisearch:clear_indexes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             rails-version: 5.2
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
-    name: integration-tests (Rails ${{ matrix.rails-version }})
+    name: integration-tests (Rails ${{ matrix.rails-version }} with Ruby ${{ matrix.ruby-version }})
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
         rails-version: [5.2, 6.1, 7.0]
         exclude:
           - ruby-version: "3.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["2.6", "2.7", "3.0", "3.1"]
-        rails-version: [4.2, 5.2, 6.1, 7.0]
+        rails-version: [5.2, 6.1, 7.0]
         exclude:
-          - ruby-version: "3.0"
-            rails-version: 4.2
-          - ruby-version: "3.1"
-            rails-version: 4.2
           - ruby-version: "3.0"
             rails-version: 5.2
           - ruby-version: "3.1"

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,13 @@
 status = [
-  'integration-tests (Rails 5.2)',
-  'integration-tests (Rails 6.1)',
+  'integration-tests (Rails 5.2 with Ruby 2.6)',
+  'integration-tests (Rails 5.2 with Ruby 2.7)',
+  'integration-tests (Rails 6.1 with Ruby 3.1)',
+  'integration-tests (Rails 6.1 with Ruby 2.6)',
+  'integration-tests (Rails 6.1 with Ruby 3.0)',
+  'integration-tests (Rails 6.1 with Ruby 2.7)',
+  'integration-tests (Rails 7 with Ruby 2.7)',
+  'integration-tests (Rails 7 with Ruby 3.0)',
+  'integration-tests (Rails 7 with Ruby 3.1)',
   'linter-check',
   'smoke-test'
 ]

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -157,13 +157,7 @@ module MeiliSearch
         attributes.merge!(attributes_to_hash(@additional_attributes, document)) if @additional_attributes
 
         if @options[:sanitize]
-          sanitizer = begin
-            ::HTML::FullSanitizer.new
-          rescue NameError
-            # from rails 4.2
-            ::Rails::Html::FullSanitizer.new
-          end
-          attributes = sanitize_attributes(attributes, sanitizer)
+          attributes = sanitize_attributes(attributes, ActionView::Base.full_sanitizer)
         end
 
         attributes = encode_attributes(attributes) if @options[:force_utf8_encoding]

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -157,7 +157,7 @@ module MeiliSearch
         attributes.merge!(attributes_to_hash(@additional_attributes, document)) if @additional_attributes
 
         if @options[:sanitize]
-          attributes = sanitize_attributes(attributes, ActionView::Base.full_sanitizer)
+          attributes = sanitize_attributes(attributes)
         end
 
         attributes = encode_attributes(attributes) if @options[:force_utf8_encoding]
@@ -165,14 +165,14 @@ module MeiliSearch
         attributes
       end
 
-      def sanitize_attributes(value, sanitizer)
+      def sanitize_attributes(value)
         case value
         when String
-          sanitizer.sanitize(value)
+          ActionView::Base.full_sanitizer.sanitize(value)
         when Hash
-          value.each { |key, val| value[key] = sanitize_attributes(val, sanitizer) }
+          value.each { |key, val| value[key] = sanitize_attributes(val) }
         when Array
-          value.map { |item| sanitize_attributes(item, sanitizer) }
+          value.map { |item| sanitize_attributes(item) }
         else
           value
         end


### PR DESCRIPTION
This PR runs the integration tests against multiple Ruby versions just to make sure everything is compatible. 

Ruby versions need to be specified as strings so that they're parsed correctly. This is an issue with GitHub Actions: https://github.com/actions/runner/issues/849

It also adds Rails 7.0 to the test suite. Rails 5.2 isn't compatible with Ruby 3+ so it's excluded and can be dropped soon since it will be EOL.

This also now caches bundle install to speed up the CI for future runs. This required moving the flags to environment variables instead. https://github.com/ruby/setup-ruby#caching-bundle-install-automatically

I didn't know if it made sense to run the linter and smoke tests against multiple Ruby versions, so I left those out. Let me know if we should do that too.