### PR TITLE
Fix release version checker

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,7 +2,7 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/v')
-file_tag=$(grep 'VERSION = ' lib/meilisearch/version.rb | cut -d '=' -f 2- | tr -d ' ' | tr -d \')
+file_tag=$(grep 'VERSION = ' lib/meilisearch/rails/version.rb | cut -d '=' -f 2- | tr -d ' ' | tr -d \')
 if [ "$current_tag" != "$file_tag" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$current_tag vs $file_tag"


### PR DESCRIPTION
After the big breaking change from 0.4.x to 0.5.x we should have to change the release script as well. Since I didn't change the latest release failed to be released.
