### PR TITLE
Remove duplicated gem versions from the gemspec/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
+
+gemspec
 
 gem 'rubysl', '~> 2.0', platform: :rbx if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source 'http://rubygems.org'
 
-gem 'json', '~> 2.5', '>= 2.5.1'
-gem 'meilisearch', '~> 0.18.0'
-
 gem 'rubysl', '~> 2.0', platform: :rbx if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 
 group :development do

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -1,19 +1,21 @@
-require File.join(File.dirname(__FILE__), 'lib', 'meilisearch', 'rails', 'version')
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'date'
+require 'meilisearch/rails/version'
 
 Gem::Specification.new do |s|
   s.name = 'meilisearch-rails'
   s.version = MeiliSearch::Rails::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Meili']
-  s.description = 'Meilisearch integration for Ruby on Rails. See https://github.com/meilisearch/meilisearch'
   s.email = 'bonjour@meilisearch.com'
-  s.homepage = 'http://github.com/meilisearch/meilisearch-rails'
-  s.licenses = ['MIT']
-  s.require_paths = ['lib']
+
+  s.description = 'Meilisearch integration for Ruby on Rails. See https://github.com/meilisearch/meilisearch'
+  s.homepage = 'https://github.com/meilisearch/meilisearch-rails'
   s.summary = 'Meilisearch integration for Ruby on Rails.'
+  s.licenses = 'MIT'
+
+  s.require_paths = ['lib']
 
   s.extra_rdoc_files = [
     'LICENSE',
@@ -32,6 +34,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_dependency('json', ['~> 2'])
-  s.add_dependency('meilisearch', ['~> 0.18'])
+  s.add_dependency 'meilisearch', '~> 0.18'
 end

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   ]
 
   s.required_ruby_version = '>= 2.6.0'
-  s.add_dependency('json', ['>= 1.5.1'])
-  s.add_dependency('meilisearch', ['>= 0.15.4'])
+
+  s.add_dependency('json', ['~> 2'])
+  s.add_dependency('meilisearch', ['~> 0.18'])
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,14 @@
+require 'bundler/setup'
+
 require 'simplecov'
 SimpleCov.start do
   add_filter %r{^/spec/}
   minimum_coverage 86.70
 end
 
-require 'rubygems'
-require 'bundler'
 require 'timeout'
 require 'dotenv/load'
 require 'faker'
-Bundler.setup :test
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
This removes the duplicated gem from the gemspec/Gemfile, I could not found a reason to be like this (I also checked for other well know gems and they only define dependencies in the gemspec, the Gemfile contains only dependencies for tests/development/benchmarks, etc - not shipped to the end-user).