### PR TITLE
Improve Docker configuration in the package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,14 @@ First of all, thank you for contributing to Meilisearch! The goal of this docume
 
 ### Setup <!-- omit in toc -->
 
+You can set up your local environment natively or using `docker`, check out the [`docker-compose.yml`](/docker-compose.yml).
+
+Example of running all the checks with docker:
+```bash
+docker-compose run --rm package bash -c "bundle install && bundle exec rspec && bundle exec rubocop"
+```
+
+To install dependencies:
 ```bash
 bundle install
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: ruby:2.6
     tty: true
     stdin_open: true
-    working_dir: /home/app
+    working_dir: /home/package
     environment:
       - MEILISEARCH_HOST=http://meilisearch:7700
       - MEILISEARCH_PORT=7700
@@ -21,15 +21,13 @@ services:
       - "3001:3000"
     volumes:
       - bundle:/vendor/bundle
-      - ./:/home/app
-      - ../meilisearch-ruby:/home/meilisearch-ruby
+      - ./:/home/package
+      # - ../meilisearch-ruby:/home/meilisearch-ruby
 
   meilisearch:
-    image: getmeili/meilisearch:v0.26.1
-    tty: true
-    stdin_open: true
+    image: getmeili/meilisearch:latest
     ports:
       - "7700"
-    # Uncomment this to run the test suite
     environment:
       - MEILI_MASTER_KEY=masterKey
+      - MEILI_NO_ANALYTICS=true


### PR DESCRIPTION
This is part of the proposal to solve the https://github.com/meilisearch/integration-guides/issues/199

- Map to `/package` instead of `/app`.
- Remove `tty` and `stdin_open` in the `meilisearch` service (it is not required, only to the `package` service)
- Use `/package` everywhere.
- Add the `bundle` volume to map the dependencies and prevent downloading the same thing every time.
- Add `MEILI_NO_ANALYTICS` to prevent misleading the analytics numbers.