### PR TITLE
Update version for the next release (v0.7.0)

### DIFF
--- a/lib/meilisearch/rails/version.rb
+++ b/lib/meilisearch/rails/version.rb
@@ -2,6 +2,6 @@
 
 module MeiliSearch
   module Rails
-    VERSION = '0.6.0'
+    VERSION = '0.7.0'
   end
 end


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥 Breaking changes

:warning: Small disclaimer: All the `raw*` methods are a direct connection between your Rails application and Meilisearch, you may find changes that are not present in this section.

- This release is **only** compatible with the latest version of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0)


Thanks again to @brunoocasali 🎉
