### PR TITLE
Add support for snake_case option in the pagination

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -599,12 +599,12 @@ module MeiliSearch
 
       def ms_search(query, params = {})
         if MeiliSearch::Rails.configuration[:pagination_backend]
-
           page = params[:page].nil? ? params[:page] : params[:page].to_i
           hits_per_page = params[:hitsPerPage].nil? ? params[:hitsPerPage] : params[:hitsPerPage].to_i
+          hits_per_page ||= params[:hits_per_page].nil? ? params[:hits_per_page] : params[:hits_per_page].to_i
 
-          params.delete(:page)
-          params.delete(:hitsPerPage)
+          %i[page hitsPerPage hits_per_page].each { |param| params.delete(param) }
+
           params[:limit] = 200
         end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1170,23 +1170,34 @@ describe 'Kaminari' do
     hits = Restaurant.search ''
     expect(hits.total_count).to eq(Restaurant.raw_search('')['hits'].size)
 
-    p1 = Restaurant.search '', page: 1, hitsPerPage: 1
+    p1 = Restaurant.search '', page: 1, hits_per_page: 1
     expect(p1.size).to eq(1)
     expect(p1[0]).to eq(hits[0])
     expect(p1.total_count).to eq(Restaurant.raw_search('')['hits'].count)
 
-    p2 = Restaurant.search '', page: 2, hitsPerPage: 1
+    p2 = Restaurant.search '', page: 2, hits_per_page: 1
     expect(p2.size).to eq(1)
     expect(p2[0]).to eq(hits[1])
     expect(p2.total_count).to eq(Restaurant.raw_search('')['hits'].count)
   end
 
+  it 'respects both camelCase and snake_case options' do
+    expect(Restaurant.count).to be > 1
+
+    # TODO: deprecate all camelcase attributes on v1.
+    %i[hits_per_page hitsPerPage].each do |method|
+      restaurants = Restaurant.search '', { page: 1, method => 1 }
+
+      expect(restaurants.size).to eq(1)
+    end
+  end
+
   it 'does not return error if pagination params are strings' do
-    p1 = Restaurant.search '', page: '1', hitsPerPage: '1'
+    p1 = Restaurant.search '', page: '1', hits_per_page: '1'
     expect(p1.size).to eq(1)
     expect(p1.total_count).to eq(Restaurant.raw_search('')['hits'].count)
 
-    p2 = Restaurant.search '', page: '2', hitsPerPage: '1'
+    p2 = Restaurant.search '', page: '2', hits_per_page: '1'
     expect(p2.size).to eq(1)
     expect(p2.total_count).to eq(Restaurant.raw_search('')['hits'].count)
   end
@@ -1208,29 +1219,29 @@ describe 'Will_paginate' do
   end
 
   it 'paginates' do
-    hits = Movies.search '', hitsPerPage: 2
+    hits = Movies.search '', hits_per_page: 2
     expect(hits.per_page).to eq(2)
     expect(hits.total_pages).to eq(5)
     expect(hits.total_entries).to eq(Movies.raw_search('')['hits'].count)
   end
 
   it 'returns most relevant elements in the first page' do
-    hits = Movies.search '', hitsPerPage: 2
+    hits = Movies.search '', hits_per_page: 2
     raw_hits = Movies.raw_search ''
     expect(hits[0]['id']).to eq(raw_hits['hits'][0]['id'].to_i)
 
-    hits = Movies.search '', hitsPerPage: 2, page: 2
+    hits = Movies.search '', hits_per_page: 2, page: 2
     raw_hits = Movies.raw_search ''
     expect(hits[0]['id']).to eq(raw_hits['hits'][2]['id'].to_i)
   end
 
   it 'does not return error if pagination params are strings' do
-    hits = Movies.search '', hitsPerPage: '5'
+    hits = Movies.search '', hits_per_page: '5'
     expect(hits.per_page).to eq(5)
     expect(hits.total_pages).to eq(2)
     expect(hits.current_page).to eq(1)
 
-    hits = Movies.search '', hitsPerPage: '5', page: '2'
+    hits = Movies.search '', hits_per_page: '5', page: '2'
     expect(hits.current_page).to eq(2)
   end
 end


### PR DESCRIPTION
Fix https://github.com/meilisearch/meilisearch-rails/issues/183

After this PR: https://github.com/meilisearch/meilisearch-rails/pull/49/files, we started to support snake_case options only in some attributes related to the Meilisearch engine like `sortableAttributes`.
And here https://github.com/meilisearch/meilisearch-rails/pull/154, I updated all the non-snake case attributes massively without checking if there was a missing spot like this.

TL;DR: 

`hitsPerPage` and `hits_per_page` should work fine now.