### PR TITLE
Replaced MEILISEARCH_HOST by MEILISEARCH_URL in the docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     stdin_open: true
     working_dir: /home/package
     environment:
-      - MEILISEARCH_HOST=http://meilisearch:7700
+      - MEILISEARCH_URL=http://meilisearch:7700
       - MEILISEARCH_PORT=7700
       - BUNDLE_PATH=/vendor/bundle
     depends_on:


### PR DESCRIPTION

## Related issue
Fixes #199

## What does this PR do?
- naming fixed


