### PR TITLE
Add pagination handler using finite pagination

### DIFF
--- a/lib/meilisearch/rails/pagination/kaminari.rb
+++ b/lib/meilisearch/rails/pagination/kaminari.rb
@@ -35,7 +35,7 @@ module MeiliSearch
             if array.empty? && !results.empty?
               # since Kaminari 0.16.0, you need to pad the results with nil values so it matches the offset param
               # otherwise you'll get an empty array: https://github.com/amatsuda/kaminari/commit/29fdcfa8865f2021f710adaedb41b7a7b081e34d
-              results = ([nil] * offset) + results
+              results = Array.new(offset) + results
               array = new results, offset: offset, limit: options[:per_page], total_count: total_hits
             end
 

--- a/lib/meilisearch/rails/pagination/will_paginate.rb
+++ b/lib/meilisearch/rails/pagination/will_paginate.rb
@@ -11,9 +11,7 @@ module MeiliSearch
       class WillPaginate
         def self.create(results, total_hits, options = {})
           ::WillPaginate::Collection.create(options[:page], options[:per_page], total_hits) do |pager|
-            start = (options[:page] - 1) * options[:per_page]
-            paginated_results = results[start, options[:per_page]]
-            pager.replace paginated_results
+            pager.replace results
           end
         end
       end


### PR DESCRIPTION
The change was more straightforward than I expected. I removed the placeholder search and mapped the response from the Meilisearch server. Also, I ensure we will always have a `page = 1` when we have a `pagination_backend` set.

All the tests passed locally (by using meilisearch-ruby with the v0.30 changes). So I can assume, based on our coverage, we are good to go.

- [ ] Test how pagy will react to those changes