### PR TITLE
Add a snippet to help testing this gem w/ local meilisearch-ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+# gem 'meilisearch', path: '../meilisearch-ruby'
+
 gemspec
 
 gem 'rubysl', '~> 2.0', platform: :rbx if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'


### PR DESCRIPTION
To prevent google searches everytime someone have to try a local `meilisearch-ruby` version in the rails gem.