### PR TITLE
Release v0.8.0

### DIFF
--- a/lib/meilisearch/rails/version.rb
+++ b/lib/meilisearch/rails/version.rb
@@ -2,7 +2,7 @@
 
 module MeiliSearch
   module Rails
-    VERSION = '0.7.3'
+    VERSION = '0.8.0'
 
     def self.qualified_version
       "Meilisearch Rails (v#{VERSION})"

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_dependency 'meilisearch', '~> 0.20.0'
+  s.add_dependency 'meilisearch', '~> 0.21.0'
 end


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## ⚠️ Breaking changes

This release is **only** compatible with the latest version of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) and greater

* Rename meilisearch_host to meilisearch_url (#197) @AdoPi

## 🚀 Enhancements

* Add the ability to define `pagination` settings in the model directly. (#208) @yagince
* Use **finite pagination** strategy when `pagination_backend` is defined. (#214) @brunoocasali 
  Read more about it [here](https://github.com/meilisearch/specifications/pull/196)
 
Thanks again to @AdoPi,  @brunoocasali, @curquiza, and @yagince! 🎉



