### PR TITLE
Improve playground setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,22 +83,25 @@ bundle exec rubocop --auto-gen-config
 
 ### Playground <!-- omit in toc -->
 
-First, you need to run a Meilisearch instance:
+Check the [playground's README](./playground/README.md) for more information.
+
+Use docker to run the playground environment:
 
 ```bash
-docker run -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics
+docker-compose up playground
 ```
 
-To test directly your changes in `meilisearch-rails`, you can run the Rails playground:
+It will use your local `meilisearch-rails` source code as the `meilisearch-rails` gem.
+And will get the same `meilisearch` instance running as the `package` service.
+
+#### Troubleshoot:
+
+If for some reason the app does not start open a `playground` console with `docker-compose run --rm playground bash` and run these administrative commands:
 
 ```bash
-cd playground
+yarn install
 bundle install
-bundle exec rails db:create
-bundle exec rails db:migrate
-bundle exec rails db:seed
-bundle exec rails webpacker:install
-bundle exec rails server
+bundle exec rails db:setup
 ```
  ⚠️ Set your Meilisearch credentials by modifying the file [`playground/config/initializers/meilisearch.rb`](/playground/config/initializers/meilisearch.rb)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 volumes:
   bundle:
+  play_bundle:
 
 services:
   package:
@@ -17,12 +18,28 @@ services:
       - meilisearch
     links:
       - meilisearch
-    ports:
-      - "3001:3000"
     volumes:
       - bundle:/vendor/bundle
       - ./:/home/package
       # - ../meilisearch-ruby:/home/meilisearch-ruby
+
+  playground:
+    build:
+      context: ./playground
+    environment:
+      - MEILISEARCH_HOST=http://meilisearch:7700
+      - BUNDLE_PATH=/vendor/bundle
+    depends_on:
+      - meilisearch
+    working_dir: /home/app
+    links:
+      - meilisearch
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./playground:/home/app
+      - ./:/home/meilisearch-rails
+      - play_bundle:/vendor/bundle
 
   meilisearch:
     image: getmeili/meilisearch:latest

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:3.1.2-slim
+ENV LANG C.UTF-8
+
+RUN apt-get update -qq && apt-get install -yq --no-install-recommends \
+    build-essential \
+    gnupg2 \
+    less \
+    git \
+    telnet \
+    nodejs \
+    npm \
+    python \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN apt-get update -qq && apt-get install -y libpq-dev
+RUN npm install -g yarn
+
+EXPOSE  3000
+CMD yarn install && bundle install && rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0'

--- a/playground/Gemfile
+++ b/playground/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '~> 3.1'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3'
 # Use sqlite3 as the database for Active Record
@@ -64,4 +62,3 @@ gem 'will_paginate', '~> 3.3'
 gem 'pagy', '~> 5.10'
 
 gem 'net-smtp', require: false
-

--- a/playground/Gemfile
+++ b/playground/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.9'
+ruby '~> 3.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3'
@@ -56,10 +56,12 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'meilisearch-rails', path: '../'
-
 gem 'faker', '~> 2.17'
 
+gem 'meilisearch-rails', path: '../'
 gem 'kaminari', '~> 1.2', '>= 1.2.1'
-
 gem 'will_paginate', '~> 3.3'
+gem 'pagy', '~> 5.10'
+
+gem 'net-smtp', require: false
+

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,24 +1,29 @@
-# README
+## Meilisearch::Rails playground 
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+**Use Docker to setup your environment.**
 
-Things you may want to cover:
+Run all the setup commands in a instance of the container `docker-compose run --rm playground bash` then:
 
-* Ruby version
+- `bundle install`
+- `yarn install`
+- `bundle exec rails db:setup`
 
-* System dependencies
+To start the app use:
 
-* Configuration
+`docker-compose up playground`
 
-* Database creation
+Then check http://0.0.0.0:3000 
 
-* Database initialization
+You can run any other rails-related code in the container:
 
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+```bash
+docker-compose run --rm playground bash
+root@49ebb83ca4bf:/home/app# bundle exec rails c
+Running via Spring preloader in process 28
+Loading development environment (Rails 6.1.7)
+irb(main):001:0> Book.count
+   (1.2ms)  SELECT sqlite_version(*)
+   (0.7ms)  SELECT COUNT(*) FROM "books"
+=> 50
+irb(main):002:0>
+```

--- a/playground/app/controllers/search_controller.rb
+++ b/playground/app/controllers/search_controller.rb
@@ -1,8 +1,8 @@
 class SearchController < ApplicationController
-    def index
-        @q = params['book'] && params['book']['q']
-        @hits = Book.search('') if @q.blank?
+  def index
+    @q = params['book'] && params['book']['q']
+    @hits = Book.search('') if @q.blank?
 
-        @hits = Book.search(@q, { hitsPerPage: 5, page: (params['page'] || 1) })
-    end    
+    @hits = Book.search(@q, { hitsPerPage: 5, page: (params['page'] || 1) })
+  end
 end

--- a/playground/app/models/song.rb
+++ b/playground/app/models/song.rb
@@ -1,0 +1,6 @@
+class Song < ApplicationRecord
+  include MeiliSearch::Rails
+  extend Pagy::Meilisearch
+
+  meilisearch
+end

--- a/playground/config/initializers/pagy.rb
+++ b/playground/config/initializers/pagy.rb
@@ -1,0 +1,1 @@
+require 'pagy/extras/meilisearch'

--- a/playground/db/migrate/20221128210955_create_songs.rb
+++ b/playground/db/migrate/20221128210955_create_songs.rb
@@ -1,0 +1,12 @@
+class CreateSongs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :songs do |t|
+      t.string :title
+      t.string :author
+      t.string :writer
+      t.text :lyrics
+
+      t.timestamps
+    end
+  end
+end

--- a/playground/db/schema.rb
+++ b/playground/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_14_105805) do
+ActiveRecord::Schema.define(version: 2022_11_28_210955) do
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -19,6 +19,15 @@ ActiveRecord::Schema.define(version: 2021_04_14_105805) do
     t.string "publisher"
     t.string "genre"
     t.integer "publication_year"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "songs", force: :cascade do |t|
+    t.string "title"
+    t.string "author"
+    t.string "writer"
+    t.text "lyrics"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/playground/db/seeds.rb
+++ b/playground/db/seeds.rb
@@ -9,14 +9,24 @@
 require 'faker'
 
 Book.destroy_all
+Song.destroy_all
 
 50.times do
-    Book.create(
-        title: Faker::Book.title, 
-        description: Faker::Lorem.paragraph_by_chars,
-        author: Faker::Book.author,
-        publisher: Faker::Book.publisher,
-        genre: Faker::Book.genre,
-        publication_year: Faker::Number.within(range: 1800..2020)
-    )
+  Book.create(
+    title: Faker::Book.title,
+    description: Faker::Lorem.paragraph_by_chars,
+    author: Faker::Book.author,
+    publisher: Faker::Book.publisher,
+    genre: Faker::Book.genre,
+    publication_year: Faker::Number.within(range: 1800..2020)
+  )
+end
+
+50.times do
+  Song.create(
+    title: Faker::Music::PearlJam.song,
+    author: Faker::Music::Hiphop.artist,
+    lyrics: Faker::Lorem.paragraphs(number: 10).join("\n"),
+    writer: Faker::Music::PearlJam.musician,
+  )
 end


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch-rails/issues/155

- Add a README that explains how to use the playground
- Add docker-compose service `playground`, which is possible to run and see the front-end at `localhost:3000`.
- Fix playground required ruby and gem versions.