### PR TITLE
Create a simple way to retrieve formatted objects from meilisearch in AR models

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -658,6 +658,11 @@ module MeiliSearch
           o = results_by_id[hit[ms_pk(meilisearch_options).to_s].to_s]
           if o
             o.formatted = hit['_formatted']
+            o.formatted.map do |k, v|
+              next if o[k] == v
+
+              o.define_singleton_method("formatted_#{k}".to_sym, lambda { v })
+            end
             o
           end
         end.compact

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -743,6 +743,30 @@ describe 'attributes_to_crop' do
   end
 end
 
+describe 'highlight attributes' do
+  before do
+    ['Locomotive Bar & Restaurant', 'Rails Bar & Restaurant'].map do |name|
+      Restaurant.create(
+        name: name,
+        kind: Faker::Restaurant.type,
+        description: Faker::Restaurant.description
+      )
+    end
+
+    Restaurant.reindex!(MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
+    sleep 0.5
+  end
+
+  it 'has convenience methods to highlight data' do
+    results = Restaurant.search('bar', { attributes_to_highlight: ['name'] })
+
+    expect(results[0]).to respond_to(:formatted_name)
+    expect(results[0].formatted_name).to eq('Locomotive <em>Bar</em>')
+    expect(results[1]).to respond_to(:formatted_name)
+    expect(results[1].formatted_name).to eq('<em>Bar</em>Restaurant')
+  end
+end
+
 describe 'Disabled' do
   before(:all) do
     DisabledBoolean.index.delete_all_documents!


### PR DESCRIPTION
**This is still a draft. I'm thinking about it**

When you have a search request with highlighted attributes you can just:

```ruby
books = Book.search('harry', { attributes_to_highlight: ['title'] })
books.first.formatted_title

# instead of

books = Book.search('harry', { attributes_to_highlight: ['title'] })
books.first.formatted['title']
```