### PR TITLE
Release v0.8.1

### DIFF
--- a/lib/meilisearch/rails/version.rb
+++ b/lib/meilisearch/rails/version.rb
@@ -2,7 +2,7 @@
 
 module MeiliSearch
   module Rails
-    VERSION = '0.8.0'
+    VERSION = '0.8.1'
 
     def self.qualified_version
       "Meilisearch Rails (v#{VERSION})"


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 :tada:
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes.

### 🚀 Enhancements 

* Update meilisearch-ruby to latest version `v0.22.0` (#231) @brunoocasali 

Thanks again @brunoocasali 🎉 