### PR TITLE
Add option to specify app name for index

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -683,13 +683,11 @@ module MeiliSearch
         global_options ||= MeiliSearch::Rails.configuration
 
         name = options[:index_uid] || model_name.to_s.gsub('::', '_').downcase
-        name = [].tap { |a|
+       [].tap do |a|
           a << global_options[:index_uid_prefix] if global_options[:index_uid_prefix]
           a << name
           a << ::Rails.env if global_options[:per_environment]
-        }.join("_")
-
-        name
+       end.join('_')
       end
 
       def ms_must_reindex?(document)

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -682,8 +682,13 @@ module MeiliSearch
         options ||= meilisearch_options
         global_options ||= MeiliSearch::Rails.configuration
 
-        name = options[:index_uid] || model_name.to_s.gsub('::', '_')
-        name = "#{name}_#{::Rails.env}" if global_options[:per_environment]
+        name = options[:index_uid] || model_name.to_s.gsub('::', '_').downcase
+        name = [].tap { |a|
+          a << gloabl_options[:per_app] if global_options[:per_app]
+          a << name
+          a << ::Rails.env if global_options[:per_environment]
+        }.join("_")
+        # name = "#{name}_#{::Rails.env}" if global_options[:per_environment]
 
         name
       end

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -684,11 +684,10 @@ module MeiliSearch
 
         name = options[:index_uid] || model_name.to_s.gsub('::', '_').downcase
         name = [].tap { |a|
-          a << global_options[:per_app] if global_options[:per_app]
+          a << global_options[:index_uid_prefix] if global_options[:index_uid_prefix]
           a << name
           a << ::Rails.env if global_options[:per_environment]
         }.join("_")
-        # name = "#{name}_#{::Rails.env}" if global_options[:per_environment]
 
         name
       end

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -684,7 +684,7 @@ module MeiliSearch
 
         name = options[:index_uid] || model_name.to_s.gsub('::', '_').downcase
         name = [].tap { |a|
-          a << gloabl_options[:per_app] if global_options[:per_app]
+          a << global_options[:per_app] if global_options[:per_app]
           a << name
           a << ::Rails.env if global_options[:per_environment]
         }.join("_")


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Adds a global option to specify an app name for use in the index name.

App name can be specified like:

```
MeiliSearch::Rails.configuration = {
  per_app: "app_name"
}
```

and will be prefixed to the index like `app_name_{index_uid}`.

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!