### PR TITLE
Deprecate Ruby 2.6 & Rails 5.2 officially

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails-version: [5.2, 6.1]
+        rails-version: [6.1, 7.0]
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     name: integration-tests-against-rc (Rails ${{ matrix.rails-version }})
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.0
       - name: Install dependencies
         run: bundle install
       - name: Get the latest Meilisearch RC

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
-        rails-version: [5.2, 6.1, 7.0]
-        exclude:
-          - ruby-version: "3.0"
-            rails-version: 5.2
-          - ruby-version: "3.1"
-            rails-version: 5.2
-          - ruby-version: "2.6"
-            rails-version: 7.0
+        ruby-version: ["2.7", "3.0", "3.1"]
+        rails-version: [6.1, 7.0]
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     name: integration-tests (Rails ${{ matrix.rails-version }} with Ruby ${{ matrix.ruby-version }})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 RUN apt-get update -y && apt-get install -y nodejs

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
 end
 
 group :test do
-  rails_version = ENV['RAILS_VERSION'] || '5.2'
+  rails_version = ENV['RAILS_VERSION'] || '6.1'
   sequel_version = ENV['SEQUEL_VERSION'] ? "~> #{ENV['SEQUEL_VERSION']}" : '>= 4.0'
 
   gem 'active_model_serializers'

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This package guarantees compatibility with [version v1.x of Meilisearch](https:/
 
 ## 🔧 Installation <!-- omit in toc -->
 
-This package requires Ruby version 2.6.0 or later and Rails 5.2 or later.
+This package requires Ruby version 2.7.0 or later and Rails 6.1 or later. It may work in older versions but it is not officially supported.
 
 With `gem` in command line:
 ```bash

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,5 @@
 status = [
-  'integration-tests (Rails 5.2 with Ruby 2.6)',
-  'integration-tests (Rails 5.2 with Ruby 2.7)',
   'integration-tests (Rails 6.1 with Ruby 3.1)',
-  'integration-tests (Rails 6.1 with Ruby 2.6)',
   'integration-tests (Rails 6.1 with Ruby 3.0)',
   'integration-tests (Rails 6.1 with Ruby 2.7)',
   'integration-tests (Rails 7 with Ruby 2.7)',


### PR DESCRIPTION
- Deprecate Ruby 2.6 and Ruby on Rails 5.2 (both are EOL since more than 1 year ago).
- Update meilisearch to 0.25.0

The minimum required version constraint in the gemspec is still 2.6 and will remain like that until we adopt a breaking feature for that version.
This way, we let the use decide when they will be able to move on!

Introduce a change from meilisearch-ruby 0.25.0. That will trigger a warning message when used with camelCase attributes.
Check the release changelog of meilisearch-ruby: https://github.com/meilisearch/meilisearch-ruby/releases/tag/v0.25.0