### PR TITLE
Changed camel case keywords to snake case

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -48,23 +48,23 @@ module MeiliSearch
 
       # Meilisearch settings
       OPTIONS = %i[
-        searchableAttributes
-        filterableAttributes
-        sortableAttributes
-        displayedAttributes
-        distinctAttribute
+        searchable_attributes
+        filterable_attributes
+        sortable_attributes
+        displayed_attributes
+        distinct_attribute
         synonyms
-        stopWords
-        rankingRules
-        attributesToHighlight
-        attributesToCrop
-        cropLength
+        stop_words
+        ranking_rules
+        attributes_to_highlight
+        attributes_to_crop
+        crop_length
         pagination
         faceting
-        typoTolerance
+        typo_tolerance
       ].freeze
 
-      CAMELIZE_OPTIONS = %i[pagination faceting typoTolerance].freeze
+      CAMELIZE_OPTIONS = %i[pagination faceting typo_tolerance].freeze
 
       OPTIONS.each do |option|
         define_method option do |value|
@@ -265,9 +265,9 @@ module MeiliSearch
       ::MeiliSearch::Index.instance_methods(false).each do |m|
         define_method(m) do |*args, &block|
           if m == :update_settings
-            args[0].delete(:attributesToHighlight) if args[0][:attributesToHighlight]
-            args[0].delete(:attributesToCrop) if args[0][:attributesToCrop]
-            args[0].delete(:cropLength) if args[0][:cropLength]
+            args[0].delete(:attributes_to_highlight) if args[0][:attributes_to_highlight]
+            args[0].delete(:attributes_to_crop) if args[0][:attributes_to_crop]
+            args[0].delete(:crop_length) if args[0][:crop_length]
           end
 
           SafeIndex.log_or_throw(m, @raise_on_failure) do
@@ -581,15 +581,15 @@ module MeiliSearch
       def ms_raw_search(q, params = {})
         index_uid = params.delete(:index) || params.delete('index')
 
-        unless meilisearch_settings.get_setting(:attributesToHighlight).nil?
-          params[:attributesToHighlight] = meilisearch_settings.get_setting(:attributesToHighlight)
+        unless meilisearch_settings.get_setting(:attributes_to_highlight).nil?
+          params[:attributes_to_highlight] = meilisearch_settings.get_setting(:attributes_to_highlight)
         end
 
-        unless meilisearch_settings.get_setting(:attributesToCrop).nil?
-          params[:attributesToCrop] = meilisearch_settings.get_setting(:attributesToCrop)
+        unless meilisearch_settings.get_setting(:attributes_to_crop).nil?
+          params[:attributes_to_crop] = meilisearch_settings.get_setting(:attributes_to_crop)
 
-          unless meilisearch_settings.get_setting(:cropLength).nil?
-            params[:cropLength] = meilisearch_settings.get_setting(:cropLength)
+          unless meilisearch_settings.get_setting(:crop_length).nil?
+            params[:crop_length] = meilisearch_settings.get_setting(:crop_length)
           end
         end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -49,19 +49,19 @@ end
 describe 'Settings change detection' do
   it 'detects settings changes' do
     expect(Color.send(:meilisearch_settings_changed?, nil, {})).to be(true)
-    expect(Color.send(:meilisearch_settings_changed?, {}, { 'searchableAttributes' => ['name'] })).to be(true)
-    expect(Color.send(:meilisearch_settings_changed?, { 'searchableAttributes' => ['name'] },
-                      { 'searchableAttributes' => %w[name hex] })).to be(true)
-    expect(Color.send(:meilisearch_settings_changed?, { 'searchableAttributes' => ['name'] },
-                      { 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(true)
+    expect(Color.send(:meilisearch_settings_changed?, {}, { 'searchable_attributes' => ['name'] })).to be(true)
+    expect(Color.send(:meilisearch_settings_changed?, { 'searchable_attributes' => ['name'] },
+                      { 'searchable_attributes' => %w[name hex] })).to be(true)
+    expect(Color.send(:meilisearch_settings_changed?, { 'searchable_attributes' => ['name'] },
+                      { 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(true)
   end
 
   it 'does not detect settings changes' do
     expect(Color.send(:meilisearch_settings_changed?, {}, {})).to be(false)
-    expect(Color.send(:meilisearch_settings_changed?, { 'searchableAttributes' => ['name'] },
-                      { searchableAttributes: ['name'] })).to be(false)
+    expect(Color.send(:meilisearch_settings_changed?, { 'searchable_attributes' => ['name'] },
+                      { searchable_attributes: ['name'] })).to be(false)
     expect(Color.send(:meilisearch_settings_changed?,
-                      { 'searchableAttributes' => ['name'], 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] }, { 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(false)
+                      { 'searchable_attributes' => ['name'], 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] }, { 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(false)
   end
 end
 
@@ -536,7 +536,7 @@ describe 'Book' do
   it 'sanitizes attributes' do
     _hack = Book.create! name: '"><img src=x onerror=alert(1)> hack0r',
                          author: '<script type="text/javascript">alert(1)</script>', premium: true, released: true
-    b = Book.raw_search('hack', { attributesToHighlight: ['*'] })
+    b = Book.raw_search('hack', { attributes_to_highlight: ['*'] })
     expect(b['hits'].length).to eq(1)
     begin
       expect(b['hits'][0]['name']).to eq('"> hack0r').and_raise(StandardError)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -61,7 +61,7 @@ describe 'Settings change detection' do
     expect(Color.send(:meilisearch_settings_changed?, { 'searchable_attributes' => ['name'] },
                       { searchable_attributes: ['name'] })).to be(false)
     expect(Color.send(:meilisearch_settings_changed?,
-                      { 'searchable_attributes' => ['name'], 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] }, 
+                      { 'searchable_attributes' => ['name'], 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] },
                       { 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(false)
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -61,7 +61,8 @@ describe 'Settings change detection' do
     expect(Color.send(:meilisearch_settings_changed?, { 'searchable_attributes' => ['name'] },
                       { searchable_attributes: ['name'] })).to be(false)
     expect(Color.send(:meilisearch_settings_changed?,
-                      { 'searchable_attributes' => ['name'], 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] }, { 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(false)
+                      { 'searchable_attributes' => ['name'], 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] }, 
+                      { 'ranking_rules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness', 'hex:asc'] })).to be(false)
   end
 end
 


### PR DESCRIPTION
Was getting warnings in tests and logs like so:
Non-conforming attributes: searchableAttributes, sortableAttributes
Attributes will be expected to be snake_case in future versions of Meilisearch Ruby.

Changed all instances of camel case to snake case to make warnings go away and to resolve the deprecations.