### PR TITLE
Add return value to ms_index!

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -526,7 +526,8 @@ module MeiliSearch
       def ms_index!(document, synchronous = false)
         return if ms_without_auto_index_scope
 
-        tasks = ms_configurations.map do |options, settings|
+        # MS tasks to be returned
+        ms_configurations.map do |options, settings|
           next if ms_indexing_disabled?(options)
 
           primary_key = ms_primary_key_of(document, options)
@@ -550,13 +551,7 @@ module MeiliSearch
               index.delete_document(primary_key)
             end
           end
-        end
-
-        if tasks.count <= 1
-          tasks.first
-        else
-          tasks
-        end
+        end.compact
       end
 
       def ms_remove_from_index!(document, synchronous = false)

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -526,7 +526,7 @@ module MeiliSearch
       def ms_index!(document, synchronous = false)
         return if ms_without_auto_index_scope
 
-        ms_configurations.each do |options, settings|
+        tasks = ms_configurations.map do |options, settings|
           next if ms_indexing_disabled?(options)
 
           primary_key = ms_primary_key_of(document, options)
@@ -551,7 +551,12 @@ module MeiliSearch
             end
           end
         end
-        nil
+
+        if tasks.count <= 1
+          tasks.first
+        else
+          tasks
+        end
       end
 
       def ms_remove_from_index!(document, synchronous = false)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -688,12 +688,12 @@ describe 'Movie' do
     Movie.clear_index!(true)
   end
 
-  it 'returns task hash on #ms_index!' do
+  it 'returns array of single task hash on #ms_index!' do
     movie = Movie.create(title: 'Harry Potter')
 
     task = movie.ms_index!
 
-    expect(task).to have_key("taskUid")
+    expect(task).to contain_exactly(a_hash_including('taskUid'))
   end
 
   it 'does not return any record with typo' do
@@ -902,10 +902,10 @@ unless OLD_RAILS
   end
 
   describe 'DisabledEnqueuedDocument' do
-    it 'returns nil #ms_index!' do
+    it '#ms_index! returns an empty array' do
       doc = DisabledEnqueuedDocument.create! name: 'test'
 
-      expect(doc.ms_index!).to be_nil
+      expect(doc.ms_index!).to be_empty
     end
 
     it 'does not try to enqueue a job' do
@@ -917,7 +917,6 @@ unless OLD_RAILS
 
   describe 'ConditionallyEnqueuedDocument' do
     before { allow(MeiliSearch::Rails::MSJob).to receive(:perform_later).and_return(nil) }
-
 
     it 'does not try to enqueue an index job when :if option resolves to false' do
       doc = ConditionallyEnqueuedDocument.create! name: 'test', is_public: false

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -531,6 +531,18 @@ describe 'Book' do
     Book.index(safe_index_uid('Book')).delete_all_documents
   end
 
+  it 'returns array of tasks on #ms_index!' do
+    moby_dick = Book.create! name: 'Moby Dick', author: 'Herman Melville', premium: false, released: true
+
+    tasks = moby_dick.ms_index!
+
+    expect(tasks).to contain_exactly(
+      a_hash_including('uid'),
+      a_hash_including('taskUid'),
+      a_hash_including('taskUid')
+    )
+  end
+
   it 'indexes the book in 2 indexes of 3' do
     steve_jobs = Book.create! name: 'Steve Jobs', author: 'Walter Isaacson', premium: true, released: true
     results = Book.search('steve')
@@ -674,6 +686,14 @@ end
 describe 'Movie' do
   before(:all) do
     Movie.clear_index!(true)
+  end
+
+  it 'returns task hash on #ms_index!' do
+    movie = Movie.create(title: 'Harry Potter')
+
+    task = movie.ms_index!
+
+    expect(task).to have_key("taskUid")
   end
 
   it 'does not return any record with typo' do
@@ -882,6 +902,12 @@ unless OLD_RAILS
   end
 
   describe 'DisabledEnqueuedDocument' do
+    it 'returns nil #ms_index!' do
+      doc = DisabledEnqueuedDocument.create! name: 'test'
+
+      expect(doc.ms_index!).to be_nil
+    end
+
     it 'does not try to enqueue a job' do
       expect do
         DisabledEnqueuedDocument.create! name: 'test'
@@ -891,6 +917,7 @@ unless OLD_RAILS
 
   describe 'ConditionallyEnqueuedDocument' do
     before { allow(MeiliSearch::Rails::MSJob).to receive(:perform_later).and_return(nil) }
+
 
     it 'does not try to enqueue an index job when :if option resolves to false' do
       doc = ConditionallyEnqueuedDocument.create! name: 'test', is_public: false


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #271

## What does this PR do?
- Changes `#ms_index!` to pass along the task hash provided by the meilisearch gem
- Adds tests for the three possible return types 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


I'm new to this project, so I tried to keep the solution as unopinionated as possible. Please feel free to suggest changes to the implementation.