### PR TITLE
Demote sorted search to level 3 heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ harry_book.formatted # => {"id"=>"1", "name"=>"<em>Harry</em> Potter", "descript
 👉 Don't forget that `attributes_to_highlight`, `attributes_to_crop`, and
 `crop_length` can be set up in the `meilisearch` block of your model.
 
-## 🔍 Sorted search
+### 🔍 Sorted search
 
 As an example of how to use the sort option, here is how you could achieve
 returning all books sorted by title in ascending order:


### PR DESCRIPTION
Just something I noticed while editing `README.md`: `## Sorted search` seems to logically belong under `## Custom search` but it has the same level of heading (and does not have its place in the TOC).