### PR TITLE
fix: use block for each_result in multi_search

### DIFF
--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -30,8 +30,8 @@ module MeiliSearch
       end
       alias each each_hit
 
-      def each_result
-        @results.each
+      def each_result(&block)
+        @results.each(&block)
       end
 
       def to_a


### PR DESCRIPTION
Fix the each_result method for multi search requests to pass a block to the each method.