### PR TITLE
Update version for the next release (v0.13.1)

### DIFF
--- a/lib/meilisearch/rails/version.rb
+++ b/lib/meilisearch/rails/version.rb
@@ -2,7 +2,7 @@
 
 module MeiliSearch
   module Rails
-    VERSION = '0.13.0'
+    VERSION = '0.13.1'
 
     def self.qualified_version
       "Meilisearch Rails (v#{VERSION})"


### PR DESCRIPTION
Multi-search's `#each_result` had a problem that it would be nice to release as a hotfix (https://github.com/meilisearch/meilisearch-rails/pull/360).