### PR TITLE
Target ruby 3 with rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3
   SuggestExtensions: false
   Exclude:
     - playground/**/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ GlobalID.app = 'meilisearch-test'
 OLD_RAILS = Gem.loaded_specs['rails'].version < Gem::Version.new('4.0')
 NEW_RAILS = Gem.loaded_specs['rails'].version >= Gem::Version.new('6.0')
 
-Dir["#{File.dirname(__FILE__)}/support/*.rb"].sort.each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/support/*.rb"].each { |file| require file }
 
 RSpec.configure do |c|
   c.mock_with :rspec


### PR DESCRIPTION
Rubocop's config was still enforcing ruby 2 code style. This is just a step that was missing in #367.