### PR TITLE
Fix CI for after ubuntu-latest becomes ubuntu-24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
     name: integration-tests (Rails ${{ matrix.rails-version }} with Ruby ${{ matrix.ruby-version }})
     steps:
       - uses: actions/checkout@v4
+      - name: Install SQLite dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -45,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install SQLite dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         env:
@@ -70,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install SQLite dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.0", "3.1", "3.2"]
+        ruby-version: ["3.2", "3.3", "3.4"]
         rails-version: [6.1, 7.0]
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
@@ -36,7 +36,7 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.ruby-version == '3.1' && matrix.rails-version == '7.0'
+        if: matrix.ruby-version == '3.4' && matrix.rails-version == '7.0'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -50,7 +50,7 @@ jobs:
         env:
           BUNDLE_WITH: test
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.4"
           bundler-cache: true
       - name: Run linter
         run: bundle exec rubocop lib/ spec/
@@ -76,7 +76,7 @@ jobs:
           BUNDLE_WITHOUT: test
           BUNDLE_GEMFILE: ./playground/Gemfile
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.4"
           bundler-cache: true
       - name: Meilisearch (latest) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics

--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,7 @@ group :test do
   gem 'rails', "~> #{rails_version}"
   gem 'sequel', sequel_version
 
-  if Gem::Version.new(rails_version) >= Gem::Version.new('6.0')
-    gem 'sqlite3', '~> 1.4.0', platform: %i[rbx ruby]
-  else
-    gem 'sqlite3', '< 1.4.0', platform: %i[rbx ruby]
-  end
+  gem 'sqlite3', '~> 2', platform: %i[rbx ruby]
 
   gem 'activerecord-jdbc-adapter', platform: :jruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,19 @@ group :development do
 end
 
 group :test do
-  rails_version = ENV['RAILS_VERSION'] || '6.1'
+  rails_version = ENV['RAILS_VERSION'] || '7.1'
   sequel_version = ENV['SEQUEL_VERSION'] ? "~> #{ENV['SEQUEL_VERSION']}" : '>= 4.0'
 
   gem 'active_model_serializers'
   gem 'rails', "~> #{rails_version}"
   gem 'sequel', sequel_version
 
-  gem 'sqlite3', '~> 2', platform: %i[rbx ruby]
+  # remove when deprecate rails 6
+  if Gem::Version.new(rails_version) >= Gem::Version.new('7.0')
+    gem 'sqlite3', '~> 2', platform: %i[rbx ruby]
+  else
+    gem 'sqlite3', '< 2', platform: %i[rbx ruby]
+  end
 
   gem 'activerecord-jdbc-adapter', platform: :jruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
@@ -29,6 +34,7 @@ group :test do
   gem 'simplecov', require: 'false'
   gem 'simplecov-cobertura', require: 'false'
   gem 'threads'
+  gem 'logger'
 
   gem 'byebug'
   gem 'dotenv', '~> 2.7', '>= 2.7.6'

--- a/bors.toml
+++ b/bors.toml
@@ -1,10 +1,10 @@
 status = [
   'integration-tests (Rails 6.1 with Ruby 3.2)',
-  'integration-tests (Rails 6.1 with Ruby 3.1)',
-  'integration-tests (Rails 6.1 with Ruby 3.0)',
-  'integration-tests (Rails 7 with Ruby 3.0)',
-  'integration-tests (Rails 7 with Ruby 3.1)',
+  'integration-tests (Rails 6.1 with Ruby 3.3)',
+  'integration-tests (Rails 6.1 with Ruby 3.4)',
   'integration-tests (Rails 7 with Ruby 3.2)',
+  'integration-tests (Rails 7 with Ruby 3.3)',
+  'integration-tests (Rails 7 with Ruby 3.4)',
   'linter-check',
   'smoke-test',
 ]

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0.0'
 
   s.add_dependency 'meilisearch', '~> 0.28'
+  s.add_dependency 'mutex_m', '~> 0.2'
 end

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-slim
+FROM ruby:3.4-slim
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && apt-get install -yq --no-install-recommends \
@@ -9,7 +9,8 @@ RUN apt-get update -qq && apt-get install -yq --no-install-recommends \
     telnet \
     nodejs \
     npm \
-    python \
+    python3 \
+    libsqlite3-dev \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN apt-get update -qq && apt-get install -y libpq-dev

--- a/playground/Gemfile
+++ b/playground/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
-gem 'rails', '~> 6.1.3'
+gem 'rails', '~> 7.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server

--- a/playground/Gemfile
+++ b/playground/Gemfile
@@ -4,9 +4,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 5.0'
+gem 'puma'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 gem 'bootstrap', '~> 5.0.0.beta2'

--- a/playground/config/application.rb
+++ b/playground/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Playground
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
We should be able to run the CI after this PR.

Deprecate ruby 3.0 and 3.1 officially from the CI and add support to ruby 3.4