### PR TITLE
Fix will_paginate crash when Meilisearch disabled 

### DIFF
--- a/lib/meilisearch/rails/pagination/will_paginate.rb
+++ b/lib/meilisearch/rails/pagination/will_paginate.rb
@@ -10,6 +10,10 @@ module MeiliSearch
     module Pagination
       class WillPaginate
         def self.create(results, total_hits, options = {})
+          total_hits = 0 if Utilities.null_object?(total_hits)
+          options[:page] = 1 if Utilities.null_object?(options[:page])
+          options[:per_page] = 1 if Utilities.null_object?(options[:per_page])
+
           ::WillPaginate::Collection.create(options[:page], options[:per_page], total_hits) do |pager|
             pager.replace results
           end

--- a/lib/meilisearch/rails/utilities.rb
+++ b/lib/meilisearch/rails/utilities.rb
@@ -56,6 +56,10 @@ module MeiliSearch
           defined?(::Sequel::Model) && model_class < Sequel::Model
         end
 
+        def null_object?(obj)
+          obj.is_a? NullObject
+        end
+
         private
 
         def constraint_passes?(record, constraint)

--- a/spec/pagination/will_paginate_spec.rb
+++ b/spec/pagination/will_paginate_spec.rb
@@ -42,4 +42,15 @@ describe 'Pagination with will_paginate' do
   it 'respects max_total_hits' do
     expect(Movie.search('*').count).to eq(5)
   end
+
+  it 'does not crash when meilisearch is disabled' do
+    MeiliSearch::Rails.configuration[:active] = false
+
+    expect do
+      Movie.search ''
+    end.not_to raise_error
+
+  ensure
+    MeiliSearch::Rails.configuration[:active] = true
+  end
 end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #382

I added a utility method to make the check for NullObject clearer than just testing for `nil?`. I'm still not a fan of the solution, I think it would be best if it was behind a `Meilisearch::Rails.active?` if statement.

Please let me know what you think.