### PR TITLE
Rename MeiliSearch to Meilisearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ gem 'meilisearch-rails'
 Create a new file `config/initializers/meilisearch.rb` to setup your `MEILISEARCH_HOST` and `MEILISEARCH_API_KEY`
 
 ```ruby
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://localhost:7700'),
   meilisearch_api_key: ENV.fetch('MEILISEARCH_API_KEY', 'YourMeilisearchAPIKey')
 }
@@ -120,7 +120,7 @@ The following code will create a `Book` index and add search capabilities to you
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch do
     attribute :title, :author # only the attributes 'title', and 'author' will be sent to Meilisearch
@@ -154,7 +154,7 @@ Requests made to Meilisearch may timeout and retry. To adapt the behavior to
 your needs, you can change the parameters during configuration:
 
 ```ruby
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: 'YourMeilisearchUrl',
   meilisearch_api_key: 'YourMeilisearchAPIKey',
   timeout: 2,
@@ -172,7 +172,7 @@ You can configure the index settings by adding them inside the `meilisearch` blo
 
 ```ruby
 class Book < ApplicationRecord
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch do
     searchable_attributes [:title, :author, :publisher, :description]
@@ -235,7 +235,7 @@ Book.search('*', sort: ['title:asc'])
 Meilisearch supports searching multiple models at the same time (see [🔍 Custom search](#-custom-search) for search options):
 
 ```ruby
-multi_search_results = MeiliSearch::Rails.multi_search(
+multi_search_results = Meilisearch::Rails.multi_search(
   Book => { q: 'Harry' },
   Manga => { q: 'Attack' }
 )
@@ -268,7 +268,7 @@ Use `#each_result` to loop through pairs of your provided keys and the results:
 Records are loaded when the keys are models, or when `:class_name` option is passed:
 
 ```ruby
-multi_search_results = MeiliSearch::Rails.multi_search(
+multi_search_results = Meilisearch::Rails.multi_search(
   'books' => { q: 'Harry', class_name: 'Book' },
   'mangas' => { q: 'Attack', class_name: 'Manga' }
 )
@@ -279,7 +279,7 @@ Otherwise, hashes are returned.
 The index to search is inferred from the model if the key is a model, if the key is a string the key is assumed to be the index unless the `:index_uid` option is passed:
 
 ```ruby
-multi_search_results = MeiliSearch::Rails.multi_search(
+multi_search_results = Meilisearch::Rails.multi_search(
   'western' => { q: 'Harry', class_name: 'Book', index_uid: 'books_production' },
   'japanese' => { q: 'Attack', class_name: 'Manga', index_uid: 'mangas_production' }
 )
@@ -291,7 +291,7 @@ You can search the same index multiple times by specifying `:index_uid`:
 
 ```ruby
 query = 'hero'
-multi_search_results = MeiliSearch::Rails.multi_search(
+multi_search_results = Meilisearch::Rails.multi_search(
   'Isekai Manga' => { q: query, class_name: 'Manga', filters: 'genre:isekai', index_uid: 'mangas_production' }
   'Shounen Manga' => { q: query, class_name: 'Manga', filters: 'genre:shounen', index_uid: 'mangas_production' }
   'Steampunk Manga' => { q: query, class_name: 'Manga', filters: 'genre:steampunk', index_uid: 'mangas_production' }
@@ -333,7 +333,7 @@ This gem supports:
 Specify the `:pagination_backend` in the configuration file:
 
 ```ruby
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: 'YourMeilisearchUrl',
   meilisearch_api_key: 'YourMeilisearchAPIKey',
   pagination_backend: :kaminari # :will_paginate
@@ -382,7 +382,7 @@ Then in your model you must extend `Pagy::Meilisearch`:
 
 ```rb
 class Book < ApplicationRecord
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
   extend Pagy::Meilisearch
 
   meilisearch # ...
@@ -403,7 +403,7 @@ end
 <%== pagy_nav(@pagy) %>
 ```
 
-:warning: There is no need to set `pagination_backend` in the configuration block `MeiliSearch::Rails.configuration` for `pagy`.
+:warning: There is no need to set `pagination_backend` in the configuration block `Meilisearch::Rails.configuration` for `pagy`.
 
 Check [`ddnexus/pagy`](https://ddnexus.github.io/pagy/extras/meilisearch) for more information.
 
@@ -415,7 +415,7 @@ you have multiple ways to achieve this.
 By adding `active: false` in the configuration initializer:
 
 ```ruby
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: 'YourMeilisearchUrl',
   meilisearch_api_key: 'YourMeilisearchAPIKey',
   active: false
@@ -425,11 +425,11 @@ MeiliSearch::Rails.configuration = {
 Or you can disable programmatically:
 
 ```ruby
-MeiliSearch::Rails.deactivate! # all the following HTTP calls will be dismissed.
+Meilisearch::Rails.deactivate! # all the following HTTP calls will be dismissed.
 
 # or you can pass a block to it:
 
-MeiliSearch::Rails.deactivate! do
+Meilisearch::Rails.deactivate! do
   # every Meilisearch call here will be dismissed, no error will be raised.
   # after the block, Meilisearch state will be active. 
 end
@@ -438,7 +438,7 @@ end
 You can also activate if you deactivated earlier:
 
 ```ruby
-MeiliSearch::Rails.activate!
+Meilisearch::Rails.activate!
 ```
 
 :warning: These calls are persistent, so prefer to use the method with the block. This way, you will not forget to activate it afterward.
@@ -449,7 +449,7 @@ By default, the **index_uid** will be the class name, e.g. `Book`. You can custo
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: 'MyCustomUID'
 end
@@ -460,7 +460,7 @@ end
 You can suffix the index UID with the current Rails environment by setting it globally:
 
 ```ruby
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: 'YourMeilisearchUrl',
   meilisearch_api_key: 'YourMeilisearchAPIKey',
   per_environment: true
@@ -479,7 +479,7 @@ You can add a custom attribute by using the `add_attribute` option or by using a
 
 ```ruby
 class Author < ApplicationRecord
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch do
     attribute :first_name, :last_name
@@ -511,7 +511,7 @@ Note that the primary key must return a **unique value** otherwise your data cou
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch primary_key: :isbn # isbn is a column in your table definition.
 end
@@ -522,7 +522,7 @@ will be used as the reference to the document when Meilisearch needs it.
 
 ```rb
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch primary_key: :my_custom_ms_id
 
@@ -541,7 +541,7 @@ As soon as you use those constraints, `add_documents` and `delete_documents` cal
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch if: :published?, unless: :premium?
 
@@ -564,7 +564,7 @@ You can index a record in several indexes using the `add_index` option:
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   PUBLIC_INDEX_UID = 'Books'
   SECURED_INDEX_UID = 'PrivateBooks'
@@ -593,7 +593,7 @@ You may want to share an index between several models. You'll need to ensure you
 
 ```ruby
 class Cat < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: 'Animals', primary_key: :ms_id
 
@@ -605,7 +605,7 @@ class Cat < ActiveRecord::Base
 end
 
 class Dog < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: 'Animals', primary_key: :ms_id
 
@@ -623,7 +623,7 @@ You can configure the auto-indexing & auto-removal process to use a queue to per
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch enqueue: true # ActiveJob will be triggered using a `meilisearch` queue
 end
@@ -637,7 +637,7 @@ With **ActiveJob**:
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch enqueue: :trigger_job do
     attribute :title, :author, :description
@@ -667,7 +667,7 @@ With [**Sidekiq**](https://github.com/mperham/sidekiq):
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch enqueue: :trigger_sidekiq_job do
     attribute :title, :author, :description
@@ -697,7 +697,7 @@ With [**DelayedJob**](https://github.com/collectiveidea/delayed_job):
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch enqueue: :trigger_delayed_job do
     attribute :title, :author, :description
@@ -721,7 +721,7 @@ Extend a change to a related record.
 
 ```ruby
 class Author < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   has_many :books
   # If your association uses belongs_to
@@ -731,7 +731,7 @@ class Author < ActiveRecord::Base
 end
 
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   belongs_to :author
   after_touch :index!
@@ -750,7 +750,7 @@ With **Sequel**, you can use the `touch` plugin to propagate changes.
 ```ruby
 # app/models/author.rb
 class Author < Sequel::Model
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   one_to_many :books
 
@@ -772,7 +772,7 @@ end
 
 # app/models/book.rb
 class Book < Sequel::Model
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   many_to_one :author
   after_touch :index!
@@ -795,7 +795,7 @@ You can strip all HTML tags from your attributes with the `sanitize` option.
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch sanitize: true
 end
@@ -807,7 +807,7 @@ You can force the UTF-8 encoding of all your attributes using the `force_utf8_en
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch force_utf8_encoding: true
 end
@@ -819,7 +819,7 @@ You can eager load associations using `meilisearch_import` scope.
 
 ```ruby
 class Author < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   has_many :books
 
@@ -872,7 +872,7 @@ You can disable exceptions that could be raised while trying to reach Meilisearc
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   # Only raise exceptions in development environment.
   meilisearch raise_on_failure: Rails.env.development?
@@ -887,7 +887,7 @@ You can force indexing and removing to be synchronous by setting the following o
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true
 end
@@ -900,7 +900,7 @@ You can disable auto-indexing and auto-removing setting the following options:
 
 ```ruby
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch auto_index: false, auto_remove: false
 end

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -20,7 +20,13 @@ end
 
 require 'logger'
 
-module MeiliSearch
+# Workaround for the soft deprecation of MeiliSearch (old spelling)
+# The regular `const_get` method does not seem to work
+# too well with autoload and thus does not pull in methods
+# like `client` which are obviously vital.
+MeiliSearch::Rails = Meilisearch::Rails
+
+module Meilisearch
   module Rails
     autoload :Configuration, 'meilisearch/rails/configuration'
     extend Configuration
@@ -97,7 +103,7 @@ module MeiliSearch
               [meilisearch-rails] #{missing_searchable} declared in searchable_attributes but not in attributes. \
               Please add it to attributes if it should be searchable.
             WARNING
-            MeiliSearch::Rails.logger.warn(warning)
+            Meilisearch::Rails.logger.warn(warning)
           end
         end
       end
@@ -270,12 +276,12 @@ module MeiliSearch
       autoload :MSCleanUpJob, 'meilisearch/rails/ms_clean_up_job'
     end
 
-    # this class wraps an MeiliSearch::Index document ensuring all raised exceptions
+    # this class wraps an Meilisearch::Index document ensuring all raised exceptions
     # are correctly logged or thrown depending on the `raise_on_failure` option
     class SafeIndex
       def initialize(index_uid, raise_on_failure, options)
-        client = MeiliSearch::Rails.client
-        primary_key = options[:primary_key] || MeiliSearch::Rails::IndexSettings::DEFAULT_PRIMARY_KEY
+        client = Meilisearch::Rails.client
+        primary_key = options[:primary_key] || Meilisearch::Rails::IndexSettings::DEFAULT_PRIMARY_KEY
         @raise_on_failure = raise_on_failure.nil? || raise_on_failure
 
         SafeIndex.log_or_throw(nil, @raise_on_failure) do
@@ -285,7 +291,7 @@ module MeiliSearch
         @index = client.index(index_uid)
       end
 
-      ::MeiliSearch::Index.instance_methods(false).each do |m|
+      ::Meilisearch::Index.instance_methods(false).each do |m|
         define_method(m) do |*args, &block|
           if m == :update_settings
             args[0].delete(:attributes_to_highlight) if args[0][:attributes_to_highlight]
@@ -294,7 +300,7 @@ module MeiliSearch
           end
 
           SafeIndex.log_or_throw(m, @raise_on_failure) do
-            return MeiliSearch::Rails.black_hole unless MeiliSearch::Rails.active?
+            return Meilisearch::Rails.black_hole unless Meilisearch::Rails.active?
 
             @index.send(m, *args, &block)
           end
@@ -304,7 +310,7 @@ module MeiliSearch
       # Maually define facet_search due to complications with **opts in ruby 2.*
       def facet_search(*args, **opts)
         SafeIndex.log_or_throw(:facet_search, @raise_on_failure) do
-          return MeiliSearch::Rails.black_hole unless MeiliSearch::Rails.active?
+          return Meilisearch::Rails.black_hole unless Meilisearch::Rails.active?
 
           @index.facet_search(*args, **opts)
         end
@@ -323,7 +329,7 @@ module MeiliSearch
       def settings(*args)
         SafeIndex.log_or_throw(:settings, @raise_on_failure) do
           @index.settings(*args)
-        rescue ::MeiliSearch::ApiError => e
+        rescue ::Meilisearch::ApiError => e
           return {} if e.code == 'index_not_found' # not fatal
 
           raise e
@@ -332,11 +338,11 @@ module MeiliSearch
 
       def self.log_or_throw(method, raise_on_failure, &block)
         yield
-      rescue ::MeiliSearch::TimeoutError, ::MeiliSearch::ApiError => e
+      rescue ::Meilisearch::TimeoutError, ::Meilisearch::ApiError => e
         raise e if raise_on_failure
 
         # log the error
-        MeiliSearch::Rails.logger.info("[meilisearch-rails] #{e.message}")
+        Meilisearch::Rails.logger.info("[meilisearch-rails] #{e.message}")
         # return something
         case method.to_s
         when 'search'
@@ -349,7 +355,7 @@ module MeiliSearch
       end
     end
 
-    # these are the class methods added when MeiliSearch is included
+    # these are the class methods added when Meilisearch is included
     module ClassMethods
       def self.extended(base)
         class << base
@@ -379,7 +385,7 @@ module MeiliSearch
         attr_accessor :formatted
 
         if options.key?(:per_environment)
-          raise BadConfiguration, ':per_environment option should be defined globally on MeiliSearch::Rails.configuration block.'
+          raise BadConfiguration, ':per_environment option should be defined globally on Meilisearch::Rails.configuration block.'
         end
 
         if options[:synchronous] == true
@@ -415,7 +421,7 @@ module MeiliSearch
                    raise ArgumentError, "Invalid `enqueue` option: #{options[:enqueue]}"
                  end
           meilisearch_options[:enqueue] = proc do |record, remove|
-            proc.call(record, remove) if ::MeiliSearch::Rails.active? && !ms_without_auto_index_scope
+            proc.call(record, remove) if ::Meilisearch::Rails.active? && !ms_without_auto_index_scope
           end
         end
         unless options[:auto_index] == false
@@ -499,7 +505,7 @@ module MeiliSearch
         Thread.current["ms_without_auto_index_scope_for_#{model_name}"]
       end
 
-      def ms_reindex!(batch_size = MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, synchronous = false)
+      def ms_reindex!(batch_size = Meilisearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, synchronous = false)
         return if ms_without_auto_index_scope
 
         ms_configurations.each do |options, settings|
@@ -622,7 +628,7 @@ module MeiliSearch
 
           index = ms_ensure_init(options, settings)
           synchronous || options[:synchronous] ? index.delete_all_documents.await : index.delete_all_documents
-          @ms_indexes[MeiliSearch::Rails.active?][settings] = nil
+          @ms_indexes[Meilisearch::Rails.active?][settings] = nil
         end
         nil
       end
@@ -666,7 +672,7 @@ module MeiliSearch
       end
 
       def ms_search(query, params = {})
-        if MeiliSearch::Rails.configuration[:pagination_backend]
+        if Meilisearch::Rails.configuration[:pagination_backend]
           %i[page hitsPerPage hits_per_page].each do |key|
             params[key.to_s.underscore.to_sym] = params[key].to_i if params.key?(key)
           end
@@ -736,7 +742,7 @@ module MeiliSearch
 
       def ms_index_uid(options = nil)
         options ||= meilisearch_options
-        global_options ||= MeiliSearch::Rails.configuration
+        global_options ||= Meilisearch::Rails.configuration
 
         name = options[:index_uid] || model_name.to_s.gsub('::', '_')
         name = "#{name}_#{::Rails.env}" if global_options[:per_environment]
@@ -788,11 +794,11 @@ module MeiliSearch
 
         @ms_indexes ||= { true => {}, false => {} }
 
-        @ms_indexes[MeiliSearch::Rails.active?][settings] ||= SafeIndex.new(ms_index_uid(options), meilisearch_options[:raise_on_failure], meilisearch_options)
+        @ms_indexes[Meilisearch::Rails.active?][settings] ||= SafeIndex.new(ms_index_uid(options), meilisearch_options[:raise_on_failure], meilisearch_options)
 
-        update_settings_if_changed(@ms_indexes[MeiliSearch::Rails.active?][settings], options, user_configuration)
+        update_settings_if_changed(@ms_indexes[Meilisearch::Rails.active?][settings], options, user_configuration)
 
-        @ms_indexes[MeiliSearch::Rails.active?][settings]
+        @ms_indexes[Meilisearch::Rails.active?][settings]
       end
 
       private
@@ -845,7 +851,7 @@ module MeiliSearch
       end
 
       def ms_pk(options = nil)
-        options[:primary_key] || MeiliSearch::Rails::IndexSettings::DEFAULT_PRIMARY_KEY
+        options[:primary_key] || Meilisearch::Rails::IndexSettings::DEFAULT_PRIMARY_KEY
       end
 
       def meilisearch_settings_changed?(server_state, user_configuration)

--- a/lib/meilisearch/rails/configuration.rb
+++ b/lib/meilisearch/rails/configuration.rb
@@ -1,4 +1,4 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     module Configuration
       def configuration
@@ -44,11 +44,11 @@ module MeiliSearch
       def client
         return black_hole unless active?
 
-        ::MeiliSearch::Client.new(
+        ::Meilisearch::Client.new(
           configuration[:meilisearch_url] || 'http://localhost:7700',
           configuration[:meilisearch_api_key],
           configuration.slice(:timeout, :max_retries)
-                       .merge(client_agents: MeiliSearch::Rails.qualified_version)
+                       .merge(client_agents: Meilisearch::Rails.qualified_version)
         )
       end
     end

--- a/lib/meilisearch/rails/errors.rb
+++ b/lib/meilisearch/rails/errors.rb
@@ -1,4 +1,4 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     class NoBlockGiven < StandardError; end
 
@@ -6,7 +6,7 @@ module MeiliSearch
 
     class NotConfigured < StandardError
       def message
-        'Please configure Meilisearch. Set MeiliSearch::Rails.configuration = ' \
+        'Please configure Meilisearch. Set Meilisearch::Rails.configuration = ' \
           "{meilisearch_url: 'YOUR_MEILISEARCH_URL', meilisearch_api_key: 'YOUR_API_KEY'}"
       end
     end

--- a/lib/meilisearch/rails/ms_clean_up_job.rb
+++ b/lib/meilisearch/rails/ms_clean_up_job.rb
@@ -1,11 +1,11 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     class MSCleanUpJob < ::ActiveJob::Base
       queue_as :meilisearch
 
       def perform(documents)
         documents.each do |document|
-          index = MeiliSearch::Rails.client.index(document[:index_uid])
+          index = Meilisearch::Rails.client.index(document[:index_uid])
 
           if document[:synchronous]
             index.delete_document(document[:primary_key]).await

--- a/lib/meilisearch/rails/ms_job.rb
+++ b/lib/meilisearch/rails/ms_job.rb
@@ -1,4 +1,4 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     class MSJob < ::ActiveJob::Base
       queue_as :meilisearch

--- a/lib/meilisearch/rails/multi_search.rb
+++ b/lib/meilisearch/rails/multi_search.rb
@@ -1,6 +1,6 @@
 require_relative 'multi_search/result'
 
-module MeiliSearch
+module Meilisearch
   module Rails
     class << self
       def multi_search(searches)
@@ -44,7 +44,7 @@ module MeiliSearch
       end
 
       def pagination_enabled?
-        MeiliSearch::Rails.configuration[:pagination_backend]
+        Meilisearch::Rails.configuration[:pagination_backend]
       end
     end
   end

--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -1,4 +1,4 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     class MultiSearchResult
       attr_reader :metadata
@@ -23,7 +23,7 @@ module MeiliSearch
       include Enumerable
 
       def each_hit(&block)
-        MeiliSearch::Rails.logger.warn(
+        Meilisearch::Rails.logger.warn(
           <<~DEPRECATION
             [meilisearch-rails] Flattening multi search results is deprecated.
             If you do not want the results to be grouped, please use federated search instead.
@@ -36,7 +36,7 @@ module MeiliSearch
       end
 
       def each(&block)
-        MeiliSearch::Rails.logger.info(
+        Meilisearch::Rails.logger.info(
           <<~INFO
             [meilisearch-rails] #each on a multi search now iterates through grouped results.
             If you do not want the results to be grouped, please use federated search instead.
@@ -52,7 +52,7 @@ module MeiliSearch
       end
 
       def to_a
-        MeiliSearch::Rails.logger.warn(
+        Meilisearch::Rails.logger.warn(
           <<~DEPRECATION
             [meilisearch-rails] Flattening multi search results is deprecated.
             If you do not want the results to be grouped, please use federated search instead.

--- a/lib/meilisearch/rails/null_object.rb
+++ b/lib/meilisearch/rails/null_object.rb
@@ -1,6 +1,6 @@
 require 'singleton'
 
-module MeiliSearch
+module Meilisearch
   module Rails
     class NullObject
       include Singleton

--- a/lib/meilisearch/rails/pagination.rb
+++ b/lib/meilisearch/rails/pagination.rb
@@ -1,11 +1,11 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     module Pagination
       autoload :WillPaginate, 'meilisearch/rails/pagination/will_paginate'
       autoload :Kaminari, 'meilisearch/rails/pagination/kaminari'
 
       def self.create(results, total_hits, options = {})
-        pagination_backend = MeiliSearch::Rails.configuration[:pagination_backend]
+        pagination_backend = Meilisearch::Rails.configuration[:pagination_backend]
 
         if pagination_backend.nil? || (is_pagy = pagination_backend.to_s == 'pagy')
           log_pagy_error if is_pagy
@@ -17,12 +17,12 @@ module MeiliSearch
       end
 
       def self.log_pagy_error
-        MeiliSearch::Rails.logger
+        Meilisearch::Rails.logger
           .warn('[meilisearch-rails] Remove `pagination_backend: :pagy` from your initializer, `pagy` it is not required for `pagy`')
       end
 
       def self.load_pagination!(pagination_backend, results, total_hits, options)
-        ::MeiliSearch::Rails::Pagination
+        ::Meilisearch::Rails::Pagination
           .const_get(pagination_backend.to_s.classify)
           .create(results, total_hits, options)
       rescue NameError

--- a/lib/meilisearch/rails/pagination/kaminari.rb
+++ b/lib/meilisearch/rails/pagination/kaminari.rb
@@ -1,11 +1,11 @@
 unless defined? Kaminari
-  raise(MeiliSearch::BadConfiguration,
+  raise(Meilisearch::BadConfiguration,
         "Meilisearch: Please add 'kaminari' to your Gemfile to use kaminari pagination backend")
 end
 
 require 'kaminari/models/array_extension'
 
-module MeiliSearch
+module Meilisearch
   module Rails
     module Pagination
       class Kaminari < ::Kaminari::PaginatableArray
@@ -18,7 +18,7 @@ module MeiliSearch
         end
 
         def self.create(results, total_hits, options = {})
-          unless MeiliSearch::Rails.active?
+          unless Meilisearch::Rails.active?
             total_hits = 0
             options[:page] = 1
             options[:per_page] = 1

--- a/lib/meilisearch/rails/pagination/will_paginate.rb
+++ b/lib/meilisearch/rails/pagination/will_paginate.rb
@@ -1,16 +1,16 @@
 begin
   require 'will_paginate/collection'
 rescue LoadError
-  raise(MeiliSearch::BadConfiguration,
-        "MeiliSearch: Please add 'will_paginate' to your Gemfile to use will_paginate pagination backend")
+  raise(Meilisearch::BadConfiguration,
+        "Meilisearch: Please add 'will_paginate' to your Gemfile to use will_paginate pagination backend")
 end
 
-module MeiliSearch
+module Meilisearch
   module Rails
     module Pagination
       class WillPaginate
         def self.create(results, total_hits, options = {})
-          unless MeiliSearch::Rails.active?
+          unless Meilisearch::Rails.active?
             total_hits = 0
             options[:page] = 1
             options[:per_page] = 1

--- a/lib/meilisearch/rails/railtie.rb
+++ b/lib/meilisearch/rails/railtie.rb
@@ -1,6 +1,6 @@
 require 'rails'
 
-module MeiliSearch
+module Meilisearch
   module Rails
     class Railtie < ::Rails::Railtie
       rake_tasks do

--- a/lib/meilisearch/rails/tasks/meilisearch.rake
+++ b/lib/meilisearch/rails/tasks/meilisearch.rake
@@ -3,21 +3,21 @@ namespace :meilisearch do
   task reindex: :environment do
     puts 'Reindexing all Meilisearch models'
 
-    MeiliSearch::Rails::Utilities.reindex_all_models
+    Meilisearch::Rails::Utilities.reindex_all_models
   end
 
   desc 'Set settings to all indexes'
   task set_all_settings: :environment do
     puts 'Set settings in all Meilisearch models'
 
-    MeiliSearch::Rails::Utilities.set_settings_all_models
+    Meilisearch::Rails::Utilities.set_settings_all_models
   end
 
   desc 'Clear all indexes'
   task clear_indexes: :environment do
     puts 'Clearing indexes from all Meilisearch models'
 
-    MeiliSearch::Rails::Utilities.clear_all_indexes
+    Meilisearch::Rails::Utilities.clear_all_indexes
   end
 
   desc 'Create initializer file'

--- a/lib/meilisearch/rails/templates/initializer.rb
+++ b/lib/meilisearch/rails/templates/initializer.rb
@@ -1,4 +1,4 @@
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://localhost:7700'),
   meilisearch_api_key: ENV.fetch('MEILISEARCH_API_KEY', 'YourMeilisearchAPIKey')
 }

--- a/lib/meilisearch/rails/utilities.rb
+++ b/lib/meilisearch/rails/utilities.rb
@@ -1,4 +1,4 @@
-module MeiliSearch
+module Meilisearch
   module Rails
     module Utilities
       class << self
@@ -8,7 +8,7 @@ module MeiliSearch
           elsif ::Rails.application
             ::Rails.application.eager_load!
           end
-          klasses = MeiliSearch::Rails.instance_variable_get(:@included_in)
+          klasses = Meilisearch::Rails.instance_variable_get(:@included_in)
           (klasses + klasses.map(&:descendants).flatten).uniq
         end
 

--- a/lib/meilisearch/rails/version.rb
+++ b/lib/meilisearch/rails/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MeiliSearch
+module Meilisearch
   module Rails
     VERSION = '0.14.3'
 

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -5,7 +5,7 @@ require 'meilisearch/rails/version'
 
 Gem::Specification.new do |s|
   s.name = 'meilisearch-rails'
-  s.version = MeiliSearch::Rails::VERSION
+  s.version = Meilisearch::Rails::VERSION
 
   s.authors = ['Meili']
   s.email = 'bonjour@meilisearch.com'
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_dependency 'meilisearch', '~> 0.28.4'
+  s.add_dependency 'meilisearch', '~> 0.30.0'
   s.add_dependency 'mutex_m', '~> 0.2'
 end

--- a/playground/app/models/book.rb
+++ b/playground/app/models/book.rb
@@ -1,5 +1,5 @@
 class Book < ApplicationRecord
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch do
     # add_attribute :extra_attr

--- a/playground/app/models/song.rb
+++ b/playground/app/models/song.rb
@@ -1,5 +1,5 @@
 class Song < ApplicationRecord
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
   extend Pagy::Meilisearch
   ActiveRecord_Relation.include Pagy::Meilisearch
 

--- a/playground/config/initializers/meilisearch.rb
+++ b/playground/config/initializers/meilisearch.rb
@@ -1,4 +1,4 @@
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
     meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://localhost:7700'),
     meilisearch_api_key: 'masterKey',
     pagination_backend: :kaminari #:will_paginate

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'support/models/book'
 require 'support/models/color'
 
-describe MeiliSearch::Rails::Configuration do
-  before { stub_const('MeiliSearch::Rails::VERSION', '0.0.1') }
+describe Meilisearch::Rails::Configuration do
+  before { stub_const('Meilisearch::Rails::VERSION', '0.0.1') }
 
   let(:configuration) do
     {
@@ -13,17 +13,17 @@ describe MeiliSearch::Rails::Configuration do
   end
 
   describe '.client' do
-    let(:client_double) { double MeiliSearch::Client }
+    let(:client_double) { double Meilisearch::Client }
 
     before do
-      allow(MeiliSearch::Rails).to receive(:configuration) { configuration }
-      allow(MeiliSearch::Client).to receive(:new) { client_double }
+      allow(Meilisearch::Rails).to receive(:configuration) { configuration }
+      allow(Meilisearch::Client).to receive(:new) { client_double }
     end
 
-    it 'initializes a MeiliSearch::Client' do
-      expect(MeiliSearch::Rails.client).to eq(client_double)
+    it 'initializes a Meilisearch::Client' do
+      expect(Meilisearch::Rails.client).to eq(client_double)
 
-      expect(MeiliSearch::Client)
+      expect(Meilisearch::Client)
         .to have_received(:new)
         .with('http://localhost:7700', 's3cr3tap1k3y', client_agents: 'Meilisearch Rails (v0.0.1)')
     end
@@ -37,9 +37,9 @@ describe MeiliSearch::Rails::Configuration do
       end
 
       it 'defines a default value for meilisearch_url' do
-        expect(MeiliSearch::Rails.client).to eq(client_double)
+        expect(Meilisearch::Rails.client).to eq(client_double)
 
-        expect(MeiliSearch::Client)
+        expect(Meilisearch::Client)
           .to have_received(:new)
           .with('http://localhost:7700', 's3cr3tap1k3y', { client_agents: 'Meilisearch Rails (v0.0.1)' })
       end
@@ -56,9 +56,9 @@ describe MeiliSearch::Rails::Configuration do
       end
 
       it 'forwards them to the client' do
-        expect(MeiliSearch::Rails.client).to eq(client_double)
+        expect(Meilisearch::Rails.client).to eq(client_double)
 
-        expect(MeiliSearch::Client)
+        expect(Meilisearch::Client)
           .to have_received(:new)
           .with('http://localhost:7700', 's3cr3tap1k3y', client_agents: 'Meilisearch Rails (v0.0.1)', timeout: 2, max_retries: 1)
       end
@@ -81,18 +81,18 @@ describe MeiliSearch::Rails::Configuration do
 
   context 'when use Meilisearch without configuration' do
     around do |example|
-      config = MeiliSearch::Rails.configuration
-      MeiliSearch::Rails.configuration = nil
+      config = Meilisearch::Rails.configuration
+      Meilisearch::Rails.configuration = nil
 
       example.run
 
-      MeiliSearch::Rails.configuration = config
+      Meilisearch::Rails.configuration = config
     end
 
     it 'raise NotConfigured error' do
       expect do
-        MeiliSearch::Rails.configuration
-      end.to raise_error(MeiliSearch::Rails::NotConfigured, /Please configure Meilisearch/)
+        Meilisearch::Rails.configuration
+      end.to raise_error(Meilisearch::Rails::NotConfigured, /Please configure Meilisearch/)
     end
   end
 end

--- a/spec/integration/active_record/meilisearch_calls_are_deactivated.rb
+++ b/spec/integration/active_record/meilisearch_calls_are_deactivated.rb
@@ -2,14 +2,14 @@ require 'support/models/task'
 
 describe 'When meilisearch calls are disabled' do
   it 'does not send requests to meilisearch' do
-    MeiliSearch::Rails.deactivate!
+    Meilisearch::Rails.deactivate!
 
     expect do
       Task.create(title: 'my task #1')
       Task.search('task')
     end.not_to raise_error
 
-    MeiliSearch::Rails.activate!
+    Meilisearch::Rails.activate!
   end
 
   context 'with a block' do
@@ -17,12 +17,12 @@ describe 'When meilisearch calls are disabled' do
       Task.destroy_all
       Task.create!(title: 'deactivated #1')
 
-      MeiliSearch::Rails.deactivate! do
+      Meilisearch::Rails.deactivate! do
         # always 0 since the black hole will return the default values
         expect(Task.search('deactivated').size).to eq(0)
       end
 
-      expect(MeiliSearch::Rails).to be_active
+      expect(Meilisearch::Rails).to be_active
       expect(Task.search('#1').size).to eq(1)
     end
   end

--- a/spec/integration/active_record/ms_rails_is_included_without_block_spec.rb
+++ b/spec/integration/active_record/ms_rails_is_included_without_block_spec.rb
@@ -1,6 +1,6 @@
 require 'support/models/specialty_models'
 
-describe 'When MeiliSearch::Rails is included but not called' do
+describe 'When Meilisearch::Rails is included but not called' do
   it 'raises an error' do
     expect do
       MisconfiguredBlock.reindex!

--- a/spec/meilisearch/activation_spec.rb
+++ b/spec/meilisearch/activation_spec.rb
@@ -1,6 +1,6 @@
 require 'support/models/queued_models'
 
-describe MeiliSearch::Rails do
+describe Meilisearch::Rails do
   it 'is active by default' do
     expect(described_class).to be_active
   end

--- a/spec/ms_clean_up_job_spec.rb
+++ b/spec/ms_clean_up_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'MeiliSearch::Rails::MSCleanUpJob' do
+RSpec.describe 'Meilisearch::Rails::MSCleanUpJob' do
   include ActiveJob::TestHelper
 
   def clean_up_indexes
@@ -15,7 +15,7 @@ RSpec.describe 'MeiliSearch::Rails::MSCleanUpJob' do
     end
   end
 
-  subject(:clean_up) { MeiliSearch::Rails::MSCleanUpJob }
+  subject(:clean_up) { Meilisearch::Rails::MSCleanUpJob }
 
   let(:record) do
     Book.create name: "Moby Dick", author: "Herman Mellville",

--- a/spec/ms_job_spec.rb
+++ b/spec/ms_job_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe 'MeiliSearch::Rails::MSJob' do
+RSpec.describe 'Meilisearch::Rails::MSJob' do
   include ActiveJob::TestHelper
 
-  subject(:job) { MeiliSearch::Rails::MSJob }
+  subject(:job) { Meilisearch::Rails::MSJob }
 
   let(:record) { double }
   let(:method_name) { :index! }

--- a/spec/multi_search/result_spec.rb
+++ b/spec/multi_search/result_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MeiliSearch::Rails::MultiSearchResult do # rubocop:todo RSpec/FilePath
+describe Meilisearch::Rails::MultiSearchResult do # rubocop:todo RSpec/FilePath
   let(:raw_results) do
     {
       'results' => [
@@ -64,7 +64,7 @@ describe MeiliSearch::Rails::MultiSearchResult do # rubocop:todo RSpec/FilePath
       let(:logger) { instance_double('Logger', info: nil) }
 
       before do
-        allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+        allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
       end
 
       it 'has the same behavior as #each_result' do
@@ -94,7 +94,7 @@ describe MeiliSearch::Rails::MultiSearchResult do # rubocop:todo RSpec/FilePath
       let(:logger) { instance_double('Logger', warn: nil) }
 
       before do
-        allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+        allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
       end
 
       it 'warns about deprecation' do
@@ -108,7 +108,7 @@ describe MeiliSearch::Rails::MultiSearchResult do # rubocop:todo RSpec/FilePath
       let(:logger) { instance_double('Logger', warn: nil) }
 
       before do
-        allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+        allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
       end
 
       it 'returns the hits' do

--- a/spec/multi_search_spec.rb
+++ b/spec/multi_search_spec.rb
@@ -34,7 +34,7 @@ describe 'multi-search' do
 
   context 'with class keys' do
     it 'returns ORM records' do
-      results = MeiliSearch::Rails.multi_search(
+      results = Meilisearch::Rails.multi_search(
         Book => { q: 'Steve' },
         Product => { q: 'palm', limit: 1 },
         Color => { q: 'bl' }
@@ -50,16 +50,16 @@ describe 'multi-search' do
     context 'when index_uid is not present' do
       it 'assumes key is index and errors' do
         expect do
-          MeiliSearch::Rails.multi_search(
+          Meilisearch::Rails.multi_search(
             'test_group' => { q: 'Steve' }
           )
-        end.to raise_error(MeiliSearch::ApiError)
+        end.to raise_error(Meilisearch::ApiError)
       end
     end
 
     context 'when :index_uid is present' do
       it 'searches the correct index' do
-        results = MeiliSearch::Rails.multi_search(
+        results = Meilisearch::Rails.multi_search(
           'books' => { q: 'Steve', index_uid: Book.index.uid },
           'products' => { q: 'palm', index_uid: Product.index.uid, limit: 1 },
           'colors' => { q: 'bl', index_uid: Color.index.uid }
@@ -76,7 +76,7 @@ describe 'multi-search' do
       it 'allows searching the same index n times' do
         index_uid = Color.index.uid
 
-        results = MeiliSearch::Rails.multi_search(
+        results = Meilisearch::Rails.multi_search(
           'dark_colors' => { q: 'black', index_uid: index_uid },
           'bright_colors' => { q: 'blue', index_uid: index_uid },
           'nature_colors' => { q: 'green', index_uid: index_uid }
@@ -91,7 +91,7 @@ describe 'multi-search' do
 
       context 'when :class_name is also present' do
         it 'loads results from the correct models' do
-          results = MeiliSearch::Rails.multi_search(
+          results = Meilisearch::Rails.multi_search(
             'books' => { q: 'Steve', index_uid: Book.index.uid, class_name: 'Book' },
             'products' => { q: 'palm', limit: 1, index_uid: Product.index.uid, class_name: 'Product' },
             'colors' => { q: 'bl', index_uid: Color.index.uid, class_name: 'Color' }
@@ -107,7 +107,7 @@ describe 'multi-search' do
 
   context 'with index name keys' do
     it 'returns hashes' do
-      results = MeiliSearch::Rails.multi_search(
+      results = Meilisearch::Rails.multi_search(
         Book.index.uid => { q: 'Steve' },
         Product.index.uid.to_sym => { q: 'palm', limit: 1 },
         Color.index.uid => { q: 'bl' }
@@ -123,7 +123,7 @@ describe 'multi-search' do
 
     context 'when class_name is specified' do
       it 'returns ORM records' do
-        results = MeiliSearch::Rails.multi_search(
+        results = Meilisearch::Rails.multi_search(
           Book.index.uid => { q: 'Steve', class_name: 'Book' },
           Product.index.uid.to_sym => { q: 'palm', limit: 1, class_name: 'Product' },
           Color.index.uid => { q: 'bl', class_name: 'Color' }
@@ -136,7 +136,7 @@ describe 'multi-search' do
 
       it 'throws error if class cannot be found' do
         expect do
-          MeiliSearch::Rails.multi_search(
+          Meilisearch::Rails.multi_search(
             Book.index.uid => { q: 'Steve', class_name: 'Book' },
             Product.index.uid.to_sym => { q: 'palm', limit: 1, class_name: 'ProductOfCapitalism' },
             Color.index.uid => { q: 'bl', class_name: 'Color' }
@@ -148,7 +148,7 @@ describe 'multi-search' do
 
   context 'with a mixture of symbol and class keys' do
     it 'returns a mixture of ORM records and hashes' do
-      results = MeiliSearch::Rails.multi_search(
+      results = Meilisearch::Rails.multi_search(
         Book => { q: 'Steve' },
         Product.index.uid => { q: 'palm', limit: 1, class_name: 'Product' },
         Color.index.uid => { q: 'bl' }
@@ -164,9 +164,9 @@ describe 'multi-search' do
 
   context 'with pagination' do
     it 'properly paginates each search' do
-      MeiliSearch::Rails.configuration[:pagination_backend] = :kaminari
+      Meilisearch::Rails.configuration[:pagination_backend] = :kaminari
 
-      results = MeiliSearch::Rails.multi_search(
+      results = Meilisearch::Rails.multi_search(
         Book => { q: 'Steve' },
         Product => { q: 'palm', page: 1, hits_per_page: 1 },
         Color.index.uid => { q: 'bl', page: 1, 'hitsPerPage' => '1' }
@@ -177,7 +177,7 @@ describe 'multi-search' do
         a_hash_including('name' => 'black', 'short_name' => 'bla')
       )
 
-      MeiliSearch::Rails.configuration[:pagination_backend] = nil
+      Meilisearch::Rails.configuration[:pagination_backend] = nil
     end
   end
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -73,7 +73,7 @@ describe 'meilisearch_options' do
       i2 = NestedItem.create hidden: true
 
       i1.children << NestedItem.create(hidden: true) << NestedItem.create(hidden: true)
-      NestedItem.where(id: [i1.id, i2.id]).reindex!(MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
+      NestedItem.where(id: [i1.id, i2.id]).reindex!(Meilisearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
 
       result = NestedItem.index.get_document(i1.id)
       expect(result['nb_children']).to eq(2)
@@ -176,29 +176,29 @@ describe 'meilisearch_options' do
 
       context 'when :if is configured' do
         before do
-          allow(MeiliSearch::Rails::MSJob).to receive(:perform_later).and_return(nil)
-          allow(MeiliSearch::Rails::MSCleanUpJob).to receive(:perform_later).and_return(nil)
+          allow(Meilisearch::Rails::MSJob).to receive(:perform_later).and_return(nil)
+          allow(Meilisearch::Rails::MSCleanUpJob).to receive(:perform_later).and_return(nil)
         end
 
         it 'does not try to enqueue an index job when :if option resolves to false' do
           doc = ConditionallyEnqueuedDocument.create! name: 'test', is_public: false
 
-          expect(MeiliSearch::Rails::MSJob).not_to have_received(:perform_later).with(doc, 'ms_index!')
+          expect(Meilisearch::Rails::MSJob).not_to have_received(:perform_later).with(doc, 'ms_index!')
         end
 
         it 'enqueues an index job when :if option resolves to true' do
           doc = ConditionallyEnqueuedDocument.create! name: 'test', is_public: true
 
-          expect(MeiliSearch::Rails::MSJob).to have_received(:perform_later).with(doc, 'ms_index!')
+          expect(Meilisearch::Rails::MSJob).to have_received(:perform_later).with(doc, 'ms_index!')
         end
 
         it 'does enqueue a remove_from_index despite :if option' do
           doc = ConditionallyEnqueuedDocument.create!(name: 'test', is_public: true)
-          expect(MeiliSearch::Rails::MSJob).to have_received(:perform_later).with(doc, 'ms_index!')
+          expect(Meilisearch::Rails::MSJob).to have_received(:perform_later).with(doc, 'ms_index!')
 
           doc.destroy!
 
-          expect(MeiliSearch::Rails::MSCleanUpJob).to have_received(:perform_later).with(doc.ms_entries)
+          expect(Meilisearch::Rails::MSCleanUpJob).to have_received(:perform_later).with(doc.ms_entries)
         end
       end
     end
@@ -240,7 +240,7 @@ describe 'meilisearch_options' do
       it 'raises exception on failure' do
         expect do
           Fruit.search('', { filter: 'title = Nightshift' })
-        end.to raise_error(MeiliSearch::ApiError)
+        end.to raise_error(Meilisearch::ApiError)
       end
     end
 
@@ -252,16 +252,16 @@ describe 'meilisearch_options' do
       end
 
       context 'in case of timeout' do
-        let(:index_instance) { instance_double(MeiliSearch::Index, settings: nil, update_settings: nil) }
-        let(:slow_client) { instance_double(MeiliSearch::Client, index: index_instance) }
+        let(:index_instance) { instance_double(Meilisearch::Index, settings: nil, update_settings: nil) }
+        let(:slow_client) { instance_double(Meilisearch::Client, index: index_instance) }
 
         before do
           allow(slow_client).to receive(:create_index)
-          allow(MeiliSearch::Rails).to receive(:client).and_return(slow_client)
+          allow(Meilisearch::Rails).to receive(:client).and_return(slow_client)
         end
 
         it 'does not raise error timeouts on reindex' do
-          allow(index_instance).to receive(:add_documents).and_raise(MeiliSearch::TimeoutError)
+          allow(index_instance).to receive(:add_documents).and_raise(Meilisearch::TimeoutError)
 
           expect do
             Vegetable.create(name: 'potato')

--- a/spec/pagination/kaminari_spec.rb
+++ b/spec/pagination/kaminari_spec.rb
@@ -4,7 +4,7 @@ require 'support/models/restaurant'
 
 describe 'Pagination with kaminari' do
   before(:all) do
-    MeiliSearch::Rails.configuration[:pagination_backend] = :kaminari
+    Meilisearch::Rails.configuration[:pagination_backend] = :kaminari
     Restaurant.clear_index!
 
     3.times do
@@ -31,14 +31,14 @@ describe 'Pagination with kaminari' do
   end
 
   it "doesn't crash when meilisearch is disabled" do
-    MeiliSearch::Rails.configuration[:active] = false
+    Meilisearch::Rails.configuration[:active] = false
 
     expect do
       Restaurant.search ''
     end.not_to raise_error
 
   ensure
-    MeiliSearch::Rails.configuration[:active] = true
+    Meilisearch::Rails.configuration[:active] = true
   end
 
   it 'returns number of total results' do

--- a/spec/pagination/pagy_spec.rb
+++ b/spec/pagination/pagy_spec.rb
@@ -7,9 +7,9 @@ describe 'Pagination with pagy' do
     logger = double
 
     allow(logger).to receive(:warn)
-    allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+    allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
 
-    MeiliSearch::Rails.configuration[:pagination_backend] = :pagy
+    Meilisearch::Rails.configuration[:pagination_backend] = :pagy
 
     Movie.search('')
 

--- a/spec/pagination/will_paginate_spec.rb
+++ b/spec/pagination/will_paginate_spec.rb
@@ -4,7 +4,7 @@ require 'support/models/movie'
 
 describe 'Pagination with will_paginate' do
   before(:all) do
-    MeiliSearch::Rails.configuration[:pagination_backend] = :will_paginate
+    Meilisearch::Rails.configuration[:pagination_backend] = :will_paginate
     Movie.clear_index!
 
     6.times { Movie.create(title: Faker::Movie.title) }
@@ -44,13 +44,13 @@ describe 'Pagination with will_paginate' do
   end
 
   it 'does not crash when meilisearch is disabled' do
-    MeiliSearch::Rails.configuration[:active] = false
+    Meilisearch::Rails.configuration[:active] = false
 
     expect do
       Movie.search ''
     end.not_to raise_error
 
   ensure
-    MeiliSearch::Rails.configuration[:active] = true
+    Meilisearch::Rails.configuration[:active] = true
   end
 end

--- a/spec/safe_index_spec.rb
+++ b/spec/safe_index_spec.rb
@@ -1,6 +1,6 @@
 require 'support/models/book'
 
-describe MeiliSearch::Rails::SafeIndex do
+describe Meilisearch::Rails::SafeIndex do
   describe '#facet_search' do
     it 'accepts all params without error' do
       TestUtil.reset_books!

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -6,7 +6,7 @@ require 'support/models/specialty_models'
 require 'support/models/song'
 require 'support/models/color'
 
-describe MeiliSearch::Rails::IndexSettings do
+describe Meilisearch::Rails::IndexSettings do
   describe 'attribute' do
     context 'when passed a block' do
       it 'uses the block to determine attribute\'s value' do
@@ -92,7 +92,7 @@ describe MeiliSearch::Rails::IndexSettings do
         )
       end
 
-      Restaurant.reindex!(MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
+      Restaurant.reindex!(Meilisearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
     end
 
     it 'includes _formatted object' do
@@ -140,7 +140,7 @@ describe MeiliSearch::Rails::IndexSettings do
       let(:logger) { instance_double('Logger', warn: nil) }
 
       before do
-        allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+        allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
       end
 
       it 'warns the user' do
@@ -157,7 +157,7 @@ describe MeiliSearch::Rails::IndexSettings do
       let(:logger) { instance_double('Logger', warn: nil) }
 
       before do
-        allow(MeiliSearch::Rails).to receive(:logger).and_return(logger)
+        allow(Meilisearch::Rails).to receive(:logger).and_return(logger)
       end
 
       it 'we cannot be certain that it is not defined and don\'t warn the user' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,13 +58,13 @@ RSpec.configure do |c|
 
   # Remove all indexes setup in this run in local or CI
   c.after(:suite) do
-    MeiliSearch::Rails.configuration = {
+    Meilisearch::Rails.configuration = {
       meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://127.0.0.1:7700'),
       meilisearch_api_key: ENV.fetch('MEILISEARCH_API_KEY', 'masterKey')
     }
 
     safe_index_list.each do |index|
-      MeiliSearch::Rails.client.delete_index(index)
+      Meilisearch::Rails.client.delete_index(index)
     end
   end
 end

--- a/spec/support/1_initialize_meilisearch.rb
+++ b/spec/support/1_initialize_meilisearch.rb
@@ -1,4 +1,4 @@
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://127.0.0.1:7700'),
   meilisearch_api_key: ENV.fetch('MEILISEARCH_API_KEY', 'masterKey'),
   per_environment: true

--- a/spec/support/async_helper.rb
+++ b/spec/support/async_helper.rb
@@ -1,6 +1,6 @@
 module AsyncHelper
   def self.await_last_task
-    task = MeiliSearch::Rails.client.tasks['results'].first
-    MeiliSearch::Rails.client.wait_for_task task['uid']
+    task = Meilisearch::Rails.client.tasks['results'].first
+    Meilisearch::Rails.client.wait_for_task task['uid']
   end
 end

--- a/spec/support/dummy_classes.rb
+++ b/spec/support/dummy_classes.rb
@@ -1,5 +1,5 @@
 class Dummy
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   def self.model_name
     'Dummy'

--- a/spec/support/models/animals.rb
+++ b/spec/support/models/animals.rb
@@ -9,7 +9,7 @@ ar_schema.create_table :dogs do |t|
 end
 
 class Cat < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('animals'), synchronous: true, primary_key: :ms_id
 
@@ -21,7 +21,7 @@ class Cat < ActiveRecord::Base
 end
 
 class Dog < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('animals'), synchronous: true, primary_key: :ms_id
 

--- a/spec/support/models/book.rb
+++ b/spec/support/models/book.rb
@@ -9,7 +9,7 @@ ar_schema.create_table :books do |t|
 end
 
 class Book < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, index_uid: safe_index_uid('SecuredBook'), sanitize: true do
     searchable_attributes [:name]

--- a/spec/support/models/color.rb
+++ b/spec/support/models/color.rb
@@ -7,7 +7,7 @@ ar_schema.create_table :colors do |t|
 end
 
 class Color < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
   attr_accessor :not_indexed
 
   meilisearch synchronous: true, index_uid: safe_index_uid('Color') do

--- a/spec/support/models/disabled_models.rb
+++ b/spec/support/models/disabled_models.rb
@@ -13,19 +13,19 @@ ar_schema.create_table :disabled_symbols do |t|
 end
 
 class DisabledBoolean < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, disable_indexing: true, index_uid: safe_index_uid('DisabledBoolean')
 end
 
 class DisabledProc < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, disable_indexing: proc { true }, index_uid: safe_index_uid('DisabledProc')
 end
 
 class DisabledSymbol < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, disable_indexing: :truth, index_uid: safe_index_uid('DisabledSymbol')
 

--- a/spec/support/models/fruit.rb
+++ b/spec/support/models/fruit.rb
@@ -5,7 +5,7 @@ ar_schema.create_table :fruits do |t|
 end
 
 class Fruit < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   # only raise exceptions in development env
   meilisearch raise_on_failure: true, index_uid: safe_index_uid('Fruit') do

--- a/spec/support/models/movie.rb
+++ b/spec/support/models/movie.rb
@@ -5,7 +5,7 @@ ar_schema.create_table :movies do |t|
 end
 
 class Movie < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('Movie') do
     pagination max_total_hits: 5

--- a/spec/support/models/people.rb
+++ b/spec/support/models/people.rb
@@ -7,7 +7,7 @@ ar_schema.create_table :people do |t|
 end
 
 class People < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, index_uid: safe_index_uid('MyCustomPeople'), primary_key: :card_number,
               auto_remove: false do

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -12,7 +12,7 @@ end
 class Post < ActiveRecord::Base
   has_many :comments
 
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('Post'), synchronous: true do
     attribute :comments do
@@ -26,7 +26,7 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :post
 
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch
 end

--- a/spec/support/models/product.rb
+++ b/spec/support/models/product.rb
@@ -10,7 +10,7 @@ ar_schema.create_table :products do |t|
 end
 
 class Product < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch auto_index: false,
               if: :published?, unless: ->(o) { o.href.blank? },

--- a/spec/support/models/queued_models.rb
+++ b/spec/support/models/queued_models.rb
@@ -14,7 +14,7 @@ ar_schema.create_table :conditionally_enqueued_documents do |t|
 end
 
 class EnqueuedDocument < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   include GlobalID::Identification
 
@@ -33,7 +33,7 @@ class EnqueuedDocument < ActiveRecord::Base
 end
 
 class DisabledEnqueuedDocument < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch(enqueue: proc { |_record| raise 'enqueued' },
               index_uid: safe_index_uid('EnqueuedDocument'),
@@ -43,7 +43,7 @@ class DisabledEnqueuedDocument < ActiveRecord::Base
 end
 
 class ConditionallyEnqueuedDocument < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch(enqueue: true,
               index_uid: safe_index_uid('ConditionallyEnqueuedDocument'),

--- a/spec/support/models/restaurant.rb
+++ b/spec/support/models/restaurant.rb
@@ -8,7 +8,7 @@ end
 
 class Restaurant < ActiveRecord::Base
   include GlobalID::Identification
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('Restaurant') do
     attributes_to_crop [:description]

--- a/spec/support/models/song.rb
+++ b/spec/support/models/song.rb
@@ -8,7 +8,7 @@ ar_schema.create_table :songs do |t|
 end
 
 class Song < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   PUBLIC_INDEX_UID  = safe_index_uid('Songs')
   SECURED_INDEX_UID = safe_index_uid('PrivateSongs')

--- a/spec/support/models/specialty_models.rb
+++ b/spec/support/models/specialty_models.rb
@@ -27,7 +27,7 @@ module Namespaced
   end
 
   class Model < ActiveRecord::Base
-    include MeiliSearch::Rails
+    include Meilisearch::Rails
 
     meilisearch synchronous: true, index_uid: safe_index_uid(ms_index_uid({})) do
       attribute :customAttr do
@@ -44,7 +44,7 @@ end
 class NestedItem < ActiveRecord::Base
   has_many :children, class_name: 'NestedItem', foreign_key: 'parent_id'
 
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, index_uid: safe_index_uid('NestedItem'), unless: :hidden do
     attribute :nb_children
@@ -56,7 +56,7 @@ class NestedItem < ActiveRecord::Base
 end
 
 class MisconfiguredBlock < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 end
 
 class SerializedDocumentSerializer < ActiveModel::Serializer
@@ -64,7 +64,7 @@ class SerializedDocumentSerializer < ActiveModel::Serializer
 end
 
 class SerializedDocument < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('SerializedDocument') do
     use_serializer SerializedDocumentSerializer
@@ -72,7 +72,7 @@ class SerializedDocument < ActiveRecord::Base
 end
 
 class EncodedString < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, force_utf8_encoding: true, index_uid: safe_index_uid('EncodedString') do
     attribute :value do

--- a/spec/support/models/task.rb
+++ b/spec/support/models/task.rb
@@ -5,7 +5,7 @@ ar_schema.create_table :tasks do |t|
 end
 
 class Task < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, index_uid: safe_index_uid('Task')
 end

--- a/spec/support/models/vegetable.rb
+++ b/spec/support/models/vegetable.rb
@@ -5,7 +5,7 @@ ar_schema.create_table :vegetables do |t|
 end
 
 class Vegetable < ActiveRecord::Base
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch raise_on_failure: false, index_uid: safe_index_uid('Fruit') do
     attribute :name

--- a/spec/support/sequel_models/book.rb
+++ b/spec/support/sequel_models/book.rb
@@ -11,7 +11,7 @@ end
 class SequelBook < Sequel::Model(sequel_db)
   plugin :active_model
 
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch synchronous: true, index_uid: safe_index_uid('SequelBook'), sanitize: true do
     add_attribute :test

--- a/spec/system/tech_shop_spec.rb
+++ b/spec/system/tech_shop_spec.rb
@@ -39,7 +39,7 @@ describe 'Tech shop' do
     # Subproducts
     @camera = Camera.create!(name: 'canon eos rebel t3', href: 'canon')
 
-    Product.reindex!(MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
+    Product.reindex!(Meilisearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
   end
 
   context 'product' do
@@ -57,7 +57,7 @@ describe 'Tech shop' do
 
       products_after_clear = Product.raw_search('')['hits']
       expect(products_after_clear).to be_empty
-      Product.reindex!(MeiliSearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
+      Product.reindex!(Meilisearch::Rails::IndexSettings::DEFAULT_BATCH_SIZE, true)
 
       products_after_reindex = Product.raw_search('')['hits']
       expect(products_after_reindex).not_to be_empty

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 require 'rake'
 
-describe MeiliSearch::Rails::Utilities do
+describe Meilisearch::Rails::Utilities do
   around do |example|
-    included_in = MeiliSearch::Rails.instance_variable_get :@included_in
-    MeiliSearch::Rails.instance_variable_set :@included_in, []
+    included_in = Meilisearch::Rails.instance_variable_get :@included_in
+    Meilisearch::Rails.instance_variable_set :@included_in, []
 
     example.run
 
-    MeiliSearch::Rails.instance_variable_set :@included_in, included_in
+    Meilisearch::Rails.instance_variable_set :@included_in, included_in
   end
 
   it 'gets the models where Meilisearch module was included' do


### PR DESCRIPTION
Depends on meilisearch-ruby 0.30 where MeiliSearch was also renamed. Used this shell command to automatically rename, and then used the git diff to manually look through and make sure nothing was wrong:
```sh 
find lib/ -type f -exec sed -i 's/MeiliSearch/Meilisearch/g' {} \; 
```
(of course also ran it for spec/ and playground/ after making sure the soft deprecation allowed all tests to pass).

Ran into issues with the regular `const_missing` + `const_get` deprecation having issues with autoload-ed methods. Added a temporary workaround just for the Rails module. With this workaround there may be cases where users are not warned for using MeiliSearch, which should be investigated.

# Pull Request

## Related issue
Fixes #347