### PR TITLE
Properly constrain version of meilisearch ruby gem

### DIFF
--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_dependency 'meilisearch', '~> 0.28'
+  s.add_dependency 'meilisearch', '~> 0.28.4'
   s.add_dependency 'mutex_m', '~> 0.2'
 end


### PR DESCRIPTION
twiddle-wakka (~>) operator is not meant only for minor versions, its behavior depends on how you specify the version. ~> 0.28 will grab anything >= 0.28 and < 1, while ~> 0.28.0 will grab >= 0.28.0 to < 0.29.

For more information, see https://github.com/meilisearch/meilisearch-rails/issues/386 .

# Pull Request

## Related issue
Fixes #386
