### PR TITLE
Rename index_name option to index_uid in multi_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,25 +276,25 @@ multi_search_results = MeiliSearch::Rails.multi_search(
 
 Otherwise, hashes are returned.
 
-The index to search is inferred from the model if the key is a model, if the key is a string the key is assumed to be the index unless the `:index_name` option is passed:
+The index to search is inferred from the model if the key is a model, if the key is a string the key is assumed to be the index unless the `:index_uid` option is passed:
 
 ```ruby
 multi_search_results = MeiliSearch::Rails.multi_search(
-  'western' => { q: 'Harry', class_name: 'Book', index_name: 'books_production' },
-  'japanese' => { q: 'Attack', class_name: 'Manga', index_name: 'mangas_production' }
+  'western' => { q: 'Harry', class_name: 'Book', index_uid: 'books_production' },
+  'japanese' => { q: 'Attack', class_name: 'Manga', index_uid: 'mangas_production' }
 )
 ```
 
 ### Multi search the same index <!-- omit in toc -->
 
-You can search the same index multiple times by specifying `:index_name`:
+You can search the same index multiple times by specifying `:index_uid`:
 
 ```ruby
 query = 'hero'
 multi_search_results = MeiliSearch::Rails.multi_search(
-  'Isekai Manga' => { q: query, class_name: 'Manga', filters: 'genre:isekai', index_name: 'mangas_production' }
-  'Shounen Manga' => { q: query, class_name: 'Manga', filters: 'genre:shounen', index_name: 'mangas_production' }
-  'Steampunk Manga' => { q: query, class_name: 'Manga', filters: 'genre:steampunk', index_name: 'mangas_production' }
+  'Isekai Manga' => { q: query, class_name: 'Manga', filters: 'genre:isekai', index_uid: 'mangas_production' }
+  'Shounen Manga' => { q: query, class_name: 'Manga', filters: 'genre:shounen', index_uid: 'mangas_production' }
+  'Steampunk Manga' => { q: query, class_name: 'Manga', filters: 'genre:steampunk', index_uid: 'mangas_production' }
 )
 ```
 

--- a/lib/meilisearch/rails/multi_search.rb
+++ b/lib/meilisearch/rails/multi_search.rb
@@ -5,7 +5,7 @@ module MeiliSearch
     class << self
       def multi_search(searches)
         search_parameters = searches.map do |(index_target, options)|
-          index_target = options.delete(:index_name) || index_target
+          index_target = options.delete(:index_uid) || index_target
 
           paginate(options) if pagination_enabled?
           normalize(options, index_target)

--- a/spec/multi_search_spec.rb
+++ b/spec/multi_search_spec.rb
@@ -47,7 +47,7 @@ describe 'multi-search' do
   end
 
   context 'with arbitrary keys' do
-    context 'when index_name is not present' do
+    context 'when index_uid is not present' do
       it 'assumes key is index and errors' do
         expect do
           MeiliSearch::Rails.multi_search(
@@ -57,12 +57,12 @@ describe 'multi-search' do
       end
     end
 
-    context 'when :index_name is present' do
+    context 'when :index_uid is present' do
       it 'searches the correct index' do
         results = MeiliSearch::Rails.multi_search(
-          'books' => { q: 'Steve', index_name: Book.index.uid },
-          'products' => { q: 'palm', index_name: Product.index.uid, limit: 1 },
-          'colors' => { q: 'bl', index_name: Color.index.uid }
+          'books' => { q: 'Steve', index_uid: Book.index.uid },
+          'products' => { q: 'palm', index_uid: Product.index.uid, limit: 1 },
+          'colors' => { q: 'bl', index_uid: Color.index.uid }
         )
 
         expect(results).to contain_exactly(
@@ -74,12 +74,12 @@ describe 'multi-search' do
       end
 
       it 'allows searching the same index n times' do
-        index_name = Color.index.uid
+        index_uid = Color.index.uid
 
         results = MeiliSearch::Rails.multi_search(
-          'dark_colors' => { q: 'black', index_name: index_name },
-          'bright_colors' => { q: 'blue', index_name: index_name },
-          'nature_colors' => { q: 'green', index_name: index_name }
+          'dark_colors' => { q: 'black', index_uid: index_uid },
+          'bright_colors' => { q: 'blue', index_uid: index_uid },
+          'nature_colors' => { q: 'green', index_uid: index_uid }
         )
 
         expect(results).to contain_exactly(
@@ -92,9 +92,9 @@ describe 'multi-search' do
       context 'when :class_name is also present' do
         it 'loads results from the correct models' do
           results = MeiliSearch::Rails.multi_search(
-            'books' => { q: 'Steve', index_name: Book.index.uid, class_name: 'Book' },
-            'products' => { q: 'palm', limit: 1, index_name: Product.index.uid, class_name: 'Product' },
-            'colors' => { q: 'bl', index_name: Color.index.uid, class_name: 'Color' }
+            'books' => { q: 'Steve', index_uid: Book.index.uid, class_name: 'Book' },
+            'products' => { q: 'palm', limit: 1, index_uid: Product.index.uid, class_name: 'Product' },
+            'colors' => { q: 'bl', index_uid: Color.index.uid, class_name: 'Color' }
           )
 
           expect(results).to contain_exactly(


### PR DESCRIPTION
Made a mistake when supporting this option, at least it has not made it to release yet.