### PR TITLE
Support scopes in multi_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,12 +265,14 @@ Use `#each_result` to loop through pairs of your provided keys and the results:
 </ul>
 ```
 
-Records are loaded when the keys are models, or when `:class_name` option is passed:
+Records are loaded when the keys are models, or when `:collection` option is passed:
 
 ```ruby
 multi_search_results = Meilisearch::Rails.multi_search(
-  'books' => { q: 'Harry', class_name: 'Book' },
-  'mangas' => { q: 'Attack', class_name: 'Manga' }
+  # Collection may be a relation
+  'books' => { q: 'Harry', collection: Book.all },
+  # or a model
+  'mangas' => { q: 'Attack', collection: Manga }
 )
 ```
 
@@ -280,8 +282,8 @@ The index to search is inferred from the model if the key is a model, if the key
 
 ```ruby
 multi_search_results = Meilisearch::Rails.multi_search(
-  'western' => { q: 'Harry', class_name: 'Book', index_uid: 'books_production' },
-  'japanese' => { q: 'Attack', class_name: 'Manga', index_uid: 'mangas_production' }
+  'western' => { q: 'Harry', collection: Book, index_uid: 'books_production' },
+  'japanese' => { q: 'Attack', collection: Manga, index_uid: 'mangas_production' }
 )
 ```
 
@@ -291,10 +293,11 @@ You can search the same index multiple times by specifying `:index_uid`:
 
 ```ruby
 query = 'hero'
+
 multi_search_results = Meilisearch::Rails.multi_search(
-  'Isekai Manga' => { q: query, class_name: 'Manga', filters: 'genre:isekai', index_uid: 'mangas_production' }
-  'Shounen Manga' => { q: query, class_name: 'Manga', filters: 'genre:shounen', index_uid: 'mangas_production' }
-  'Steampunk Manga' => { q: query, class_name: 'Manga', filters: 'genre:steampunk', index_uid: 'mangas_production' }
+  'Isekai Manga' => { q: query, collection: Manga, filters: 'genre:isekai', index_uid: 'mangas_production' }
+  'Shounen Manga' => { q: query, collection: Manga, filters: 'genre:shounen', index_uid: 'mangas_production' }
+  'Steampunk Manga' => { q: query, collection: Manga, filters: 'genre:steampunk', index_uid: 'mangas_production' }
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -265,14 +265,14 @@ Use `#each_result` to loop through pairs of your provided keys and the results:
 </ul>
 ```
 
-Records are loaded when the keys are models, or when `:collection` option is passed:
+Records are loaded when the keys are models, or when `:scope` option is passed:
 
 ```ruby
 multi_search_results = Meilisearch::Rails.multi_search(
-  # Collection may be a relation
-  'books' => { q: 'Harry', collection: Book.all },
+  # scope may be a relation
+  'books' => { q: 'Harry', scope: Book.all },
   # or a model
-  'mangas' => { q: 'Attack', collection: Manga }
+  'mangas' => { q: 'Attack', scope: Manga }
 )
 ```
 
@@ -282,8 +282,8 @@ The index to search is inferred from the model if the key is a model, if the key
 
 ```ruby
 multi_search_results = Meilisearch::Rails.multi_search(
-  'western' => { q: 'Harry', collection: Book, index_uid: 'books_production' },
-  'japanese' => { q: 'Attack', collection: Manga, index_uid: 'mangas_production' }
+  'western' => { q: 'Harry', scope: Book, index_uid: 'books_production' },
+  'japanese' => { q: 'Attack', scope: Manga, index_uid: 'mangas_production' }
 )
 ```
 
@@ -295,9 +295,9 @@ You can search the same index multiple times by specifying `:index_uid`:
 query = 'hero'
 
 multi_search_results = Meilisearch::Rails.multi_search(
-  'Isekai Manga' => { q: query, collection: Manga, filters: 'genre:isekai', index_uid: 'mangas_production' }
-  'Shounen Manga' => { q: query, collection: Manga, filters: 'genre:shounen', index_uid: 'mangas_production' }
-  'Steampunk Manga' => { q: query, collection: Manga, filters: 'genre:steampunk', index_uid: 'mangas_production' }
+  'Isekai Manga' => { q: query, scope: Manga, filters: 'genre:isekai', index_uid: 'mangas_production' }
+  'Shounen Manga' => { q: query, scope: Manga, filters: 'genre:shounen', index_uid: 'mangas_production' }
+  'Steampunk Manga' => { q: query, scope: Manga, filters: 'genre:steampunk', index_uid: 'mangas_production' }
 )
 ```
 

--- a/lib/meilisearch/rails/multi_search.rb
+++ b/lib/meilisearch/rails/multi_search.rb
@@ -5,7 +5,8 @@ module Meilisearch
     class << self
       def multi_search(searches)
         search_parameters = searches.map do |(index_target, options)|
-          index_target = options.delete(:index_uid) || index_target
+          collection_class = options[:collection].respond_to?(:model) ? options[:collection].model : options[:collection]
+          index_target = options.delete(:index_uid) || collection_class || index_target
 
           paginate(options) if pagination_enabled?
           normalize(options, index_target)

--- a/lib/meilisearch/rails/multi_search.rb
+++ b/lib/meilisearch/rails/multi_search.rb
@@ -5,8 +5,8 @@ module Meilisearch
     class << self
       def multi_search(searches)
         search_parameters = searches.map do |(index_target, options)|
-          collection_class = options[:collection].respond_to?(:model) ? options[:collection].model : options[:collection]
-          index_target = options.delete(:index_uid) || collection_class || index_target
+          model_class = options[:scope].respond_to?(:model) ? options[:scope].model : options[:scope]
+          index_target = options.delete(:index_uid) || model_class || index_target
 
           paginate(options) if pagination_enabled?
           normalize(options, index_target)
@@ -19,7 +19,7 @@ module Meilisearch
 
       def normalize(options, index_target)
         options
-          .except(:class_name, :collection)
+          .except(:class_name, :scope)
           .merge!(index_uid: index_uid_from_target(index_target))
       end
 

--- a/lib/meilisearch/rails/multi_search.rb
+++ b/lib/meilisearch/rails/multi_search.rb
@@ -18,7 +18,7 @@ module Meilisearch
 
       def normalize(options, index_target)
         options
-          .except(:class_name)
+          .except(:class_name, :collection)
           .merge!(index_uid: index_uid_from_target(index_target))
       end
 

--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -14,7 +14,7 @@ module Meilisearch
                             target
                           end
 
-          @results[target] = results_class ? load_results(results_class, result) : result['hits']
+          @results[target] = results_class ? load_results(results_class, result, collection: search_options[:collection]) : result['hits']
 
           @metadata[target] = result.except('hits')
         end
@@ -69,7 +69,7 @@ module Meilisearch
 
       private
 
-      def load_results(klass, result)
+      def load_results(klass, result, collection: klass)
         pk_method = klass.ms_primary_key_method
         pk_method = pk_method.in if Utilities.mongo_model?(klass)
 
@@ -78,7 +78,7 @@ module Meilisearch
         hits_by_id =
           result['hits'].index_by { |hit| hit[condition_key.to_s] }
 
-        records = klass.where(condition_key => hits_by_id.keys)
+        records = collection.where(condition_key => hits_by_id.keys)
 
         if records.respond_to? :in_order_of
           records.in_order_of(condition_key, hits_by_id.keys).each do |record|

--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -12,6 +12,8 @@ module Meilisearch
                             search_options[:class_name].constantize
                           elsif target.instance_of?(Class)
                             target
+                          elsif search_options[:collection]
+                            search_options[:collection]
                           end
 
           @results[target] = results_class ? load_results(results_class, result, collection: search_options[:collection]) : result['hits']
@@ -69,7 +71,9 @@ module Meilisearch
 
       private
 
-      def load_results(klass, result, collection: klass)
+      def load_results(klass, result, collection:)
+        collection ||= klass
+
         pk_method = klass.ms_primary_key_method
         pk_method = pk_method.in if Utilities.mongo_model?(klass)
 

--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -10,17 +10,17 @@ module Meilisearch
         searches.zip(raw_results['results']).each do |(target, search_options), result|
           results_class = if search_options[:class_name]
                             Meilisearch::Rails.logger.warn(
-                              '[meilisearch-rails] The :class_name option in multi search is deprecated, please use :collection instead.'
+                              '[meilisearch-rails] The :class_name option in multi search is deprecated, please use :scope instead.'
                             )
 
                             search_options[:class_name].constantize
                           elsif target.instance_of?(Class)
                             target
-                          elsif search_options[:collection]
-                            search_options[:collection]
+                          elsif search_options[:scope]
+                            search_options[:scope]
                           end
 
-          @results[target] = results_class ? load_results(results_class, result, collection: search_options[:collection]) : result['hits']
+          @results[target] = results_class ? load_results(results_class, result, scope: search_options[:scope]) : result['hits']
 
           @metadata[target] = result.except('hits')
         end
@@ -75,8 +75,8 @@ module Meilisearch
 
       private
 
-      def load_results(klass, result, collection:)
-        collection ||= klass
+      def load_results(klass, result, scope:)
+        scope ||= klass
 
         pk_method = klass.ms_primary_key_method
         pk_method = pk_method.in if Utilities.mongo_model?(klass)
@@ -86,7 +86,7 @@ module Meilisearch
         hits_by_id =
           result['hits'].index_by { |hit| hit[condition_key.to_s] }
 
-        records = collection.where(condition_key => hits_by_id.keys)
+        records = scope.where(condition_key => hits_by_id.keys)
 
         if records.respond_to? :in_order_of
           records.in_order_of(condition_key, hits_by_id.keys).each do |record|

--- a/lib/meilisearch/rails/multi_search/result.rb
+++ b/lib/meilisearch/rails/multi_search/result.rb
@@ -9,6 +9,10 @@ module Meilisearch
 
         searches.zip(raw_results['results']).each do |(target, search_options), result|
           results_class = if search_options[:class_name]
+                            Meilisearch::Rails.logger.warn(
+                              '[meilisearch-rails] The :class_name option in multi search is deprecated, please use :collection instead.'
+                            )
+
                             search_options[:class_name].constantize
                           elsif target.instance_of?(Class)
                             target

--- a/spec/multi_search_spec.rb
+++ b/spec/multi_search_spec.rb
@@ -180,4 +180,17 @@ describe 'multi-search' do
       Meilisearch::Rails.configuration[:pagination_backend] = nil
     end
   end
+
+  context 'with collections' do
+    it 'fetches items from the given collection' do
+      results = MeiliSearch::Rails.multi_search(
+        Product.index.uid => { q: 'palm', class_name: 'Product', collection: Product.where('tags LIKE "%terrible%"') },
+        Color => { q: 'bl', collection: Color.where(short_name: 'bla') }
+      )
+
+      expect(results).to contain_exactly(
+        black, palm_pixi_plus
+      )
+    end
+  end
 end

--- a/spec/multi_search_spec.rb
+++ b/spec/multi_search_spec.rb
@@ -164,7 +164,7 @@ describe 'multi-search' do
     it 'returns a mixture of ORM records and hashes' do
       results = Meilisearch::Rails.multi_search(
         Book => { q: 'Steve' },
-        Product.index.uid => { q: 'palm', limit: 1, collection: Product },
+        Product.index.uid => { q: 'palm', limit: 1, scope: Product },
         Color.index.uid => { q: 'bl' }
       )
 
@@ -195,11 +195,11 @@ describe 'multi-search' do
     end
   end
 
-  context 'with collections' do
-    it 'fetches items from the given collection' do
+  context 'with scopes' do
+    it 'fetches items from the given scope' do
       results = Meilisearch::Rails.multi_search(
-        Product => { q: 'palm', collection: Product.where('tags LIKE "%terrible%"') },
-        Color => { q: 'bl', collection: Color.where(short_name: 'bla') }
+        Product => { q: 'palm', scope: Product.where('tags LIKE "%terrible%"') },
+        Color => { q: 'bl', scope: Color.where(short_name: 'bla') }
       )
 
       expect(results).to contain_exactly(
@@ -209,7 +209,7 @@ describe 'multi-search' do
 
     it 'infers the model' do
       results = Meilisearch::Rails.multi_search(
-        'colors' => { q: 'bl', collection: Color.all, index_uid: Color.index.uid }
+        'colors' => { q: 'bl', scope: Color.all, index_uid: Color.index.uid }
       )
 
       expect(results.to_h['colors']).to contain_exactly(blue, black)
@@ -217,7 +217,7 @@ describe 'multi-search' do
 
     it 'infers the index as well as the model' do
       results = Meilisearch::Rails.multi_search(
-        'colors' => { q: 'bl', collection: Color }
+        'colors' => { q: 'bl', scope: Color }
       )
 
       expect(results.to_h['colors']).to contain_exactly(blue, black)

--- a/spec/multi_search_spec.rb
+++ b/spec/multi_search_spec.rb
@@ -192,5 +192,21 @@ describe 'multi-search' do
         black, palm_pixi_plus
       )
     end
+
+    it 'infers the model' do
+      results = MeiliSearch::Rails.multi_search(
+        'colors' => { q: 'bl', collection: Color.all, index_uid: Color.index.uid }
+      )
+
+      expect(results.to_h['colors']).to contain_exactly(blue, black)
+    end
+
+    it 'infers the index as well as the model' do
+      results = MeiliSearch::Rails.multi_search(
+        'colors' => { q: 'bl', collection: Color }
+      )
+
+      expect(results.to_h['colors']).to contain_exactly(blue, black)
+    end
   end
 end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes part of #397

- This makes multi_search, like the regular search, support relations and other collections that respond to `where`.
- In favor of this new :collection option, :class_name is softly deprecated for a consistent user experience (since :collection does everything that :class_name did and more)