### PR TITLE
Add rspec status persistence file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |c|
   c.filter_run focus: true
   c.run_all_when_everything_filtered = true
   c.formatter = 'documentation'
+  c.example_status_persistence_file_path = 'spec/tmp/examples.txt'
 
   c.around do |example|
     Timeout.timeout(120) do


### PR DESCRIPTION
This allows rspec to "remember" the last test run, allowing for commands like `rspec --only-failures`, which should improve developer UX.

Picked `spec/tmp/examples.txt` since it's idiomatic to call this file examples.txt and `spec/tmp` was already in the gitignore.

It's a small thing but I don't think there's an argument against having it.