### PR TITLE
Bump meilisearch ruby to v0.32 & other small improvements

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,13 +1,13 @@
 landing_getting_started_1: |-
   # Create an initializer file like `config/initializers/meilisearch.rb`
-  MeiliSearch::Rails.configuration = {
+  Meilisearch::Rails.configuration = {
     meilisearch_url: 'http://127.0.0.1:7700',
     meilisearch_api_key: 'masterKey',
   }
 
   # Add Meilisearch to your ActiveRecord model
   class Movie < ActiveRecord::Base
-    include MeiliSearch::Rails
+    include Meilisearch::Rails
 
     meilisearch index_uid: 'movies' do
       attribute :title

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -62,7 +62,7 @@ end
 
 require 'minitest/autorun'
 
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: ENV.fetch('MEILISEARCH_HOST', 'http://127.0.0.1:7700'),
   meilisearch_api_key: ENV.fetch('MEILISEARCH_API_KEY', 'masterKey'),
   per_environment: true
@@ -91,7 +91,7 @@ MeiliSearch::Rails.configuration = {
 # end
 #
 # class ArBook < ActiveRecord::Base
-#   include MeiliSearch::Rails
+#   include Meilisearch::Rails
 #
 #   meilisearch
 # end
@@ -119,7 +119,7 @@ MeiliSearch::Rails.configuration = {
 #
 # class SequelBook < Sequel::Model(sequel_db)
 #   plugin :active_model
-#   include MeiliSearch::Rails
+#   include Meilisearch::Rails
 #
 #   meilisearch
 # end
@@ -147,15 +147,15 @@ MeiliSearch::Rails.configuration = {
 #   field :title, type: String
 #   field :price_cents, type: Integer
 #
-#   include MeiliSearch::Rails
+#   include Meilisearch::Rails
 #
 #   meilisearch
 # end
 
 # Run this method before searching to make sure Meilisearch is up to date
 def await_last_task
-  task = MeiliSearch::Rails.client.tasks['results'].first
-  MeiliSearch::Rails.client.wait_for_task task['uid']
+  task = Meilisearch::Rails.client.tasks['results'].first
+  Meilisearch::Rails.client.wait_for_task task['uid']
 end
 
 class BugTest < Minitest::Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,14 @@ services:
     environment:
       - MEILISEARCH_HOST=http://meilisearch:7700
       - MEILISEARCH_PORT=7700
+      - MONGODB_HOST=mongo:27017
       - BUNDLE_PATH=/vendor/bundle
     depends_on:
       - meilisearch
+      - mongo
     links:
       - meilisearch
+      - mongo
     volumes:
       - bundle:/vendor/bundle
       - ./:/home/package
@@ -26,12 +29,14 @@ services:
       context: ./playground
     environment:
       - MEILISEARCH_HOST=http://meilisearch:7700
+      - MONGODB_HOST=mongo:27017
       - BUNDLE_PATH=/vendor/bundle
     depends_on:
       - meilisearch
     working_dir: /home/app
     links:
       - meilisearch
+      - mongo
     ports:
       - "3000:3000"
     volumes:
@@ -46,3 +51,8 @@ services:
     environment:
       - MEILI_MASTER_KEY=masterKey
       - MEILI_NO_ANALYTICS=true
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - "27017:27017"

--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_dependency 'meilisearch', '~> 0.31.0'
+  s.add_dependency 'meilisearch', '~> 0.32.0'
   s.add_dependency 'mutex_m', '~> 0.2'
 end

--- a/spec/support/mongo_models/citizen.rb
+++ b/spec/support/mongo_models/citizen.rb
@@ -5,7 +5,7 @@ class Citizen
   field :name, type: String
   field :age, type: Integer
 
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch index_uid: safe_index_uid('Citizen')
 end


### PR DESCRIPTION
# Pull Request

## Related issue
Attempt to fix the issue no #355 

## What does this PR do?
- Replace `MeiliSearch` across the repo to `Meilisearch` (few missing spots)
- Bump meilisearch-ruby to v0.32
- Add mongodb as a service in the docker-compose (otherwise the test suite does not pass)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MongoDB service to the application stack, allowing integration with MongoDB for relevant services.
- **Bug Fixes**
  - Standardized the capitalization of the Meilisearch module name across configuration and documentation for improved consistency.
- **Chores**
  - Updated the Meilisearch gem dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->