### PR TITLE
Respect model's `self.primary_key` when creating Meilisearch indexes

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -403,13 +403,7 @@ module Meilisearch
           raise ArgumentError, 'Cannot use a enqueue if the `synchronous` option is set' if options[:synchronous]
 
           proc = if options[:enqueue] == true
-                   proc do |record, remove|
-                     if remove
-                       MSCleanUpJob.perform_later(record.ms_entries)
-                     else
-                       MSJob.perform_later(record, 'ms_index!')
-                     end
-                   end
+                   proc { |record, remove| remove ? MSCleanUpJob.perform_later(record.ms_entries) : MSJob.perform_later(record, 'ms_index!') }
                  elsif options[:enqueue].respond_to?(:call)
                    options[:enqueue]
                  elsif options[:enqueue].is_a?(Symbol)
@@ -701,11 +695,7 @@ module Meilisearch
 
         condition_key = meilisearch_options[:type].primary_key if has_virtual_column_as_pk
 
-        hit_ids = if has_virtual_column_as_pk
-                    json['hits'].map { |hit| hit[condition_key] }
-                  else
-                    json['hits'].map { |hit| hit[ms_pk(meilisearch_options).to_s] }
-                  end
+        hit_ids = json['hits'].map { |hit| hit[has_virtual_column_as_pk ? condition_key : ms_pk(meilisearch_options).to_s] }
 
         # meilisearch_options[:type] refers to the Model name (e.g. Product)
         # results_by_id creates a hash with the primaryKey of the document (id) as the key and doc itself as the value

--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -377,10 +377,7 @@ module Meilisearch
 
       def meilisearch(options = {}, &block)
         self.meilisearch_settings = IndexSettings.new(options, &block)
-        self.meilisearch_options = {
-          type: model_name.to_s.constantize,
-          per_page: meilisearch_settings.get_setting(:hitsPerPage) || 20, page: 1
-        }.merge(options)
+        self.meilisearch_options = default_meilisearch_options(meilisearch_settings, options)
 
         attr_accessor :formatted
 
@@ -804,6 +801,16 @@ module Meilisearch
       end
 
       private
+
+      def default_meilisearch_options(meilisearch_settings, options)
+        type = model_name.to_s.constantize
+        {
+          type: type,
+          per_page: meilisearch_settings.get_setting(:hitsPerPage) || 20,
+          page: 1,
+          primary_key: type.respond_to?(:primary_key) ? type.primary_key : nil
+        }.merge(options)
+      end
 
       def update_settings_if_changed(index, options, user_configuration)
         server_state = index.settings

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -5,6 +5,7 @@ require 'support/models/animals'
 require 'support/models/people'
 require 'support/models/vegetable'
 require 'support/models/fruit'
+require 'support/models/story'
 require 'support/models/disabled_models'
 require 'support/models/queued_models'
 
@@ -18,10 +19,22 @@ describe 'meilisearch_options' do
   end
 
   describe ':primary_key' do
-    it 'sets the primary key specified' do
+    it 'sets the primary key passed to #meilisearch' do
       TestUtil.reset_people!
       People.create(first_name: 'Jane', last_name: 'Doe', card_number: 75_801_887)
       expect(People.index.fetch_info.primary_key).to eq('card_number')
+    end
+
+    it 'sets the primary key defined in #primary_key' do
+      TestUtil.reset_stories!
+      Story.create(story_id: 1, title: 'A nice story')
+      expect(Story.index.fetch_info.primary_key).to eq('story_id')
+    end
+
+    it 'sets the primary key as id if not explicitly set' do
+      TestUtil.reset_books!
+      Book.create(name: 'Test Book', author: 'Test Author', premium: true, released: true, genre: 'Horror')
+      expect(Book.index.fetch_info.primary_key).to eq('id')
     end
   end
 

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -8,6 +8,7 @@ require 'support/models/fruit'
 require 'support/models/story'
 require 'support/models/disabled_models'
 require 'support/models/queued_models'
+require 'support/mongo_models/citizen'
 
 describe 'meilisearch_options' do
   describe ':index_uid' do
@@ -23,18 +24,21 @@ describe 'meilisearch_options' do
       TestUtil.reset_people!
       People.create(first_name: 'Jane', last_name: 'Doe', card_number: 75_801_887)
       expect(People.index.fetch_info.primary_key).to eq('card_number')
+      expect(MeiliSearch::Rails.client.index(People.index_uid).get_primary_key).to eq('card_number')
     end
 
     it 'sets the primary key defined in #primary_key' do
       TestUtil.reset_stories!
       Story.create(story_id: 1, title: 'A nice story')
       expect(Story.index.fetch_info.primary_key).to eq('story_id')
+      expect(MeiliSearch::Rails.client.index(Story.index_uid).get_primary_key).to eq('story_id')
     end
 
     it 'sets the primary key as id if not explicitly set' do
       TestUtil.reset_books!
       Book.create(name: 'Test Book', author: 'Test Author', premium: true, released: true, genre: 'Horror')
       expect(Book.index.fetch_info.primary_key).to eq('id')
+      expect(MeiliSearch::Rails.client.index(Book.index_uid).get_primary_key).to eq('id')
     end
   end
 

--- a/spec/support/models/story.rb
+++ b/spec/support/models/story.rb
@@ -1,0 +1,21 @@
+require 'support/active_record_schema'
+
+ar_schema.create_table :stories do |t|
+  t.integer :story_id
+  t.string :title
+end
+
+class Story < ActiveRecord::Base
+  include MeiliSearch::Rails
+
+  self.primary_key = 'story_id' # Use model primary_key for index primary key
+
+  meilisearch index_uid: safe_index_uid('MyCustomStory') # Don't set primary_key in meilisearch
+end
+
+module TestUtil
+  def self.reset_stories!
+    Story.clear_index!
+    Story.delete_all
+  end
+end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #423

## What does this PR do?

###  Before

The `Model.primary_key` is not used to set `meilisearch_options.primary_key` anywhere.

### After

Set `meilisearch_options.primary_key` from the ActiveRecord  `SomeModel.primary_key` when Rails loads the model, which calls `#meilisearch`. `SomeModel.primary_key` is `"id"` by default, or a custom key if overridden.

### Unchanged

If `primary_key` is explicitly passed to `#meilisearch`, it takes precedence. If neither is defined, the `primary_key` is set to nil.

### Why

These properties are better defined in initialize, as they are static model attributes that don’t change. This avoids redundant checks later and keeps the code cleaner and faster.

## Future work (suggestion)

I believe there are still some now redundant checks ([1](https://github.com/thicolares/meilisearch-rails/blob/1483ccfc91f2c19a6ee3b22ac617d923b6cdde88/lib/meilisearch-rails.rb#L789), [2](https://github.com/thicolares/meilisearch-rails/blob/1483ccfc91f2c19a6ee3b22ac617d923b6cdde88/lib/meilisearch-rails.rb#L856), [3](https://github.com/thicolares/meilisearch-rails/blob/1483ccfc91f2c19a6ee3b22ac617d923b6cdde88/lib/meilisearch-rails.rb#L284))  in the might that could be cleaned up in a separate PR. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures index primary key consistently matches model-defined primary key (including non-id keys).
  - Applies reliable defaults for pagination (page and per-page) when not specified.

- Refactor
  - Centralizes construction of default search options for simpler, more consistent behavior.
  - Simplifies internal option handling and ID resolution logic.

- Tests
  - Adds coverage for primary key alignment across models, including custom keys.
  - Introduces new test model to validate indexing scenarios and client-reported primary keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->