### PR TITLE
Fix conditional indexing with enqueue mode in ms_enqueue_index!

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -954,14 +954,22 @@ module Meilisearch
       end
 
       def ms_enqueue_index!(synchronous)
-        return unless Utilities.indexable?(self, meilisearch_options)
-
-        if meilisearch_options[:enqueue]
-          unless self.class.send(:ms_indexing_disabled?, meilisearch_options)
-            meilisearch_options[:enqueue].call(self, false)
+        if Utilities.indexable?(self, meilisearch_options)
+          if meilisearch_options[:enqueue]
+            unless self.class.send(:ms_indexing_disabled?, meilisearch_options)
+              meilisearch_options[:enqueue].call(self, false)
+            end
+          else
+            ms_index!(synchronous)
           end
-        else
-          ms_index!(synchronous)
+        elsif self.class.send(:ms_conditional_index?, meilisearch_options)
+          if meilisearch_options[:enqueue]
+            unless self.class.send(:ms_indexing_disabled?, meilisearch_options)
+              meilisearch_options[:enqueue].call(self, true)
+            end
+          else
+            ms_remove_from_index!(synchronous)
+          end
         end
       end
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #426

## What does this PR do?
Fixes conditional indexing when using `enqueue: true` option. Previously, when a record no longer met the indexing condition (e.g., `if: :published?` returned `false`), the document would remain in the Meilisearch index instead of being removed.

Code reflects logic implemented in `ms_index!` method.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search index update logic to properly handle conditional indexing rules and background job enqueueing, ensuring items are indexed or removed from search based on configured settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->