### PR TITLE
Remove checks on conditions in the 'ms_must_reindex?' method

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -765,19 +765,6 @@ module Meilisearch
             return true if ms_attribute_changed?(document, k)
             # return true if !document.respond_to?(changed_method) || document.send(changed_method)
           end
-          [options[:if], options[:unless]].each do |condition|
-            case condition
-            when nil
-              return false
-            when String, Symbol
-              return true if ms_attribute_changed?(document, condition)
-            else
-              # if the :if, :unless condition is a anything else,
-              # we have no idea whether we should reindex or not
-              # let's always reindex then
-              return true
-            end
-          end
         end
 
         # By default, we don't reindex


### PR DESCRIPTION
This commit removes the checks on the meilisearch conditions options `:if` and `:unless` in the `ms_must_reindex?` method as they are incorrectly used.

## Low level reason

[Indeed the README documents an example on how to avoid reindexing when an `if:` condition is defined (e.g. `if: :published?`)](https://github.com/meilisearch/meilisearch-rails/tree/main?tab=readme-ov-file#conditional-indexing). However the documented way doesn't work: Indeed, one would need to define a method `#will_save_change_to_published??` (note the two question marks) to be able to prevent reindexing. However ruby doesn't allow such a method name (with double trailing question marks).

## Higher level reason

In a high level vision, the `if:` and `unless:` conditions are used as “constraints” when the lib will try to index a resource in many different places of the code by executing `Utilities.indexable?(...)` before trying to index, those those conditions are sufficient to “enable” or “disable” the indexation of the lib, no matter what attributes change on the record.

Why would the “must_reindex” logic try to check those conditions? I admit I didn't understand and believe this code is obsolete.

What do you folks think?

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed conditional reindexing options (`:if` and `:unless`), eliminating complex conditional evaluation logic.
  * Reindexing now occurs exclusively when primary keys or tracked attributes change.
  * Simplifies the reindexing mechanism and reduces unnecessary database operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->