### PR TITLE
chore: bump meilisearch dependency to ~> 0.33.0

### DIFF
--- a/meilisearch-rails.gemspec
+++ b/meilisearch-rails.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_dependency 'meilisearch', '~> 0.32.0'
+  s.add_dependency 'meilisearch', '~> 0.33.0'
   s.add_dependency 'mutex_m', '~> 0.2'
 end


### PR DESCRIPTION
## Summary
- Bump `meilisearch` (meilisearch-ruby) dependency from `~> 0.32.0` to `~> 0.33.0`
- Picks up the security fix included in meilisearch-ruby v0.33.0 to address HTTParty CVE

## Test plan
- [ ] `bundle install` resolves successfully with meilisearch >= 0.33.0
- [ ] Existing test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded meilisearch Ruby gem dependency to version 0.33.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->