### PR TITLE
Add separator_tokens and non_separator_tokens to index settings

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -74,6 +74,8 @@ module Meilisearch
         faceting
         typo_tolerance
         proximity_precision
+        separator_tokens
+        non_separator_tokens
       ].freeze
 
       CAMELIZE_OPTIONS = %i[pagination faceting typo_tolerance].freeze

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -114,6 +114,21 @@ describe Meilisearch::Rails::IndexSettings do
     end
   end
 
+  describe 'non_separator_tokens' do
+    it 'can be set' do
+      Color.create!(name: 'dark-blue', short_name: 'db', hex: 0x00008B)
+      expect(Color.index.get_settings['nonSeparatorTokens']).to eq(['-'])
+    end
+  end
+
+  describe 'separator_tokens' do
+    it 'can be set' do
+      Song.create!(name: 'Rock & Roll', artist: 'Led Zeppelin', premium: false, released: true)
+      AsyncHelper.await_last_task
+      expect(Song.index.get_settings['separatorTokens']).to eq(['&'])
+    end
+  end
+
   describe 'proximity_precision' do
     it 'can be set to byWord' do
       expect(Color.index.get_settings['proximityPrecision']).to eq('byWord')

--- a/spec/support/models/color.rb
+++ b/spec/support/models/color.rb
@@ -26,6 +26,7 @@ class Color < ActiveRecord::Base
     attributes_to_highlight [:name]
     faceting max_values_per_facet: 20
     proximity_precision 'byWord'
+    non_separator_tokens ['-']
   end
 
   def will_save_change_to_hex?

--- a/spec/support/models/song.rb
+++ b/spec/support/models/song.rb
@@ -21,6 +21,7 @@ class Song < ActiveRecord::Base
     end
 
     proximity_precision 'byAttribute'
+    separator_tokens ['&']
   end
 
   private


### PR DESCRIPTION
### Related issue
Fixes #442

### What does this PR do?

Adds `separator_tokens` and `non_separator_tokens` to the `IndexSettings::OPTIONS` list, enabling these Meilisearch settings to be configured directly in the model DSL, just like `proximity_precision`, `typo_tolerance`, and other existing settings.

### Example

```ruby
class Article < ApplicationRecord
  include Meilisearch::Rails

  meilisearch do
    non_separator_tokens ['-']
    separator_tokens ['&']
  end
end
```

These settings control how Meilisearch tokenizes indexed content. For instance, `non_separator_tokens ['-']` prevents hyphens from splitting tokens, so a reference like `OR-JX7` is treated as a single searchable term rather than two separate words.

### Changes

- Added `separator_tokens` and `non_separator_tokens` to `IndexSettings::OPTIONS` in `lib/meilisearch-rails.rb`
- Added specs for both settings in `spec/settings_spec.rb`
- Added setting declarations to the `Color` and `Song` test models

### PR checklist

- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. **Yes, I used Cursor (Claude) to assist me.**
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `separator_tokens` and `non_separator_tokens` configuration options to customize how text is tokenized during indexing, enabling more precise control over search term matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->