### PR TITLE
Fix configuration cache ivar collision on models

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -827,20 +827,20 @@ module Meilisearch
       def ms_configurations
         raise ArgumentError, 'No `meilisearch` block found in your model.' if meilisearch_settings.nil?
 
-        if @configurations.nil?
-          @configurations = {}
-          @configurations[meilisearch_options] = meilisearch_settings
+        if @meilisearch_configurations.nil?
+          @meilisearch_configurations = {}
+          @meilisearch_configurations[meilisearch_options] = meilisearch_settings
           meilisearch_settings.additional_indexes.each do |k, v|
-            @configurations[k] = v
+            @meilisearch_configurations[k] = v
 
             next unless v.additional_indexes.any?
 
             v.additional_indexes.each do |options, index|
-              @configurations[options] = index
+              @meilisearch_configurations[options] = index
             end
           end
         end
-        @configurations
+        @meilisearch_configurations
       end
 
       def ms_primary_key_of(doc, options = nil)

--- a/spec/configurations_cache_spec.rb
+++ b/spec/configurations_cache_spec.rb
@@ -1,0 +1,28 @@
+require 'support/models/color'
+
+describe 'Configuration cache' do
+  it 'does not use a generic @configurations ivar on the model' do
+    # Ensure a clean slate even if other specs already touched the model.
+    Color.remove_instance_variable(:@meilisearch_configurations) if Color.instance_variable_defined?(:@meilisearch_configurations)
+    Color.remove_instance_variable(:@configurations) if Color.instance_variable_defined?(:@configurations)
+
+    # Simulate another gem using the same generic ivar name.
+    Color.instance_variable_set(:@configurations, { ranking: ['typo'], indexLanguages: ['ja'] })
+
+    captured_settings = nil
+    fake_index = instance_double(Meilisearch::Rails::SafeIndex, update_settings: { 'taskUid' => 0 }, wait_for_task: nil)
+
+    allow(Meilisearch::Rails::SafeIndex).to receive(:new).and_return(fake_index)
+    allow(fake_index).to receive(:update_settings) do |settings|
+      captured_settings = settings
+      { 'taskUid' => 0 }
+    end
+
+    expect { Color.ms_set_settings(false) }.not_to raise_error
+    expect(captured_settings).to be_a(Hash)
+
+    allowed_keys = Meilisearch::Rails::IndexSettings::OPTIONS
+    unexpected_keys = captured_settings.keys.map(&:to_sym) - allowed_keys
+    expect(unexpected_keys).to be_empty
+  end
+end

--- a/spec/configurations_cache_spec.rb
+++ b/spec/configurations_cache_spec.rb
@@ -1,6 +1,33 @@
 require 'support/models/color'
 
 describe 'Configuration cache' do
+  def capture_ivars(klass, *ivars)
+    ivars.index_with do |ivar|
+      [klass.instance_variable_defined?(ivar), klass.instance_variable_get(ivar)]
+    end
+  end
+
+  def restore_ivars(klass, captured)
+    captured.each do |ivar, (defined, value)|
+      if defined
+        klass.instance_variable_set(ivar, value)
+      elsif klass.instance_variable_defined?(ivar)
+        klass.remove_instance_variable(ivar)
+      end
+    end
+  end
+
+  around do |example|
+    ivars = %i[@meilisearch_configurations @configurations]
+    captured = capture_ivars(Color, *ivars)
+
+    begin
+      example.run
+    ensure
+      restore_ivars(Color, captured)
+    end
+  end
+
   it 'does not use a generic @configurations ivar on the model' do
     # Ensure a clean slate even if other specs already touched the model.
     Color.remove_instance_variable(:@meilisearch_configurations) if Color.instance_variable_defined?(:@meilisearch_configurations)


### PR DESCRIPTION
## Summary
- Namespaced the model-level configuration cache ivar used by `ms_configurations` to avoid collisions with other gems.
- Added a regression spec that simulates a third-party gem overwriting `@configurations` on the model.

## Why
`meilisearch-rails` used a generic `@configurations` class instance variable on the model to cache index configurations. Other gems can use the same ivar name on the same model, causing the cached settings to be replaced and invalid settings payloads to be sent to Meilisearch.

## Test plan
- ✅ Ran `docker-compose run --rm package bash -c "bundle exec rspec"`
- ✅ Ran `docker-compose run --rm package bash -c "bundle exec rubocop"`

## AI usage disclosure
Used Cursor (GPT-5) for assistance with identifying the collision point, drafting the minimal fix, and writing the regression test.

Refs #448

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to configuration handling for better code maintainability.

* **Tests**
  * Enhanced test coverage to verify configuration cache behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->