### PR TITLE
Enhance record update tests and refactor attribute handling

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -96,7 +96,6 @@ module Meilisearch
       def warn_searchable_missing_attributes
         searchables = get_setting(:searchable_attributes)&.map { |searchable| searchable.to_s.split('.').first }
         attrs = get_setting(:attributes)&.map { |k, _| k.to_s }
-
         if searchables.present? && attrs.present?
           (searchables - attrs).each do |missing_searchable|
             warning = <<~WARNING
@@ -110,7 +109,6 @@ module Meilisearch
 
       def use_serializer(serializer)
         @serializer = serializer
-        # instance_variable_set("@serializer", serializer)
       end
 
       def attribute(*names, &block)
@@ -147,7 +145,6 @@ module Meilisearch
 
       def get_default_attributes(document)
         if mongoid?(document)
-          # work-around mongoid 2.4's unscoped method, not accepting a block
           document.attributes
         elsif sequel?(document)
           document.to_hash
@@ -158,44 +155,34 @@ module Meilisearch
         end
       end
 
-      def get_attribute_names(document)
-        get_attributes(document).keys
+      def indexed_field_names(document)
+        base_field_names = if @serializer.nil?
+                             @attributes.present? ? @attributes.keys : get_default_attributes(document).keys
+                           else
+                             @serializer.new(document).attributes.keys
+                           end
+        (base_field_names + (@additional_attributes&.keys || [])).uniq
       end
 
       def attributes_to_hash(attributes, document)
-        if attributes
-          attributes.to_h { |name, value| [name.to_s, value.call(document)] }
-        else
-          {}
-        end
+        attributes ? attributes.to_h { |name, value| [name.to_s, value.call(document)] } : {}
       end
 
-      def get_attributes(document)
-        # If a serializer is set, we ignore attributes
-        # everything should be done via the serializer
-        if !@serializer.nil?
-          attributes = @serializer.new(document).attributes
-        elsif @attributes.blank?
-          attributes = get_default_attributes(document)
-          # no `attribute ...` have been configured, use the default attributes of the model
-        elsif active_record?(document)
-          # at least 1 `attribute ...` has been configured, therefore use ONLY the one configured
-          document.class.unscoped do
-            attributes = attributes_to_hash(@attributes, document)
-          end
-        else
-          attributes = attributes_to_hash(@attributes, document)
-        end
-
+      def build_document_attributes(document)
+        attributes = if !@serializer.nil?
+                       @serializer.new(document).attributes
+                     elsif @attributes.present?
+                       if active_record?(document)
+                         document.class.unscoped { attributes_to_hash(@attributes, document) }
+                       else
+                         attributes_to_hash(@attributes, document)
+                       end
+                     else
+                       get_default_attributes(document)
+                     end
         attributes.merge!(attributes_to_hash(@additional_attributes, document)) if @additional_attributes
-
-        if @options[:sanitize]
-          attributes = sanitize_attributes(attributes)
-        end
-
-        attributes = encode_attributes(attributes) if @options[:force_utf8_encoding]
-
-        attributes
+        attributes = sanitize_attributes(attributes) if @options[:sanitize]
+        @options[:force_utf8_encoding] ? encode_attributes(attributes) : attributes
       end
 
       def sanitize_attributes(value)
@@ -523,7 +510,7 @@ module Meilisearch
               group = group.select { |d| Utilities.indexable?(d, options) }
             end
             documents = group.map do |d|
-              attributes = settings.get_attributes(d)
+              attributes = settings.build_document_attributes(d)
               attributes = attributes.to_hash unless attributes.instance_of?(Hash)
               attributes.merge ms_pk(options) => ms_primary_key_of(d, options)
             end
@@ -554,7 +541,7 @@ module Meilisearch
           next if ms_indexing_disabled?(options)
 
           index = ms_ensure_init(options, settings)
-          task = index.add_documents(documents.map { |d| settings.get_attributes(d).merge ms_pk(options) => ms_primary_key_of(d, options) })
+          task = index.add_documents(documents.map { |d| settings.build_document_attributes(d).merge ms_pk(options) => ms_primary_key_of(d, options) })
           index.wait_for_task(task['taskUid']) if synchronous || options[:synchronous]
         end
       end
@@ -571,7 +558,7 @@ module Meilisearch
           if Utilities.indexable?(document, options)
             raise ArgumentError, 'Cannot index a record without a primary key' if primary_key.blank?
 
-            doc = settings.get_attributes(document)
+            doc = settings.build_document_attributes(document)
             doc = doc.merge ms_pk(options) => primary_key
 
             if synchronous || options[:synchronous]
@@ -761,7 +748,7 @@ module Meilisearch
           next if ms_indexing_disabled?(options)
           return true if ms_primary_key_changed?(document, options)
 
-          settings.get_attribute_names(document).each do |k|
+          settings.indexed_field_names(document).each do |k|
             return true if ms_attribute_changed?(document, k)
             # return true if !document.respond_to?(changed_method) || document.send(changed_method)
           end

--- a/spec/integration/active_record/record_is_updated_spec.rb
+++ b/spec/integration/active_record/record_is_updated_spec.rb
@@ -1,5 +1,7 @@
 require 'support/models/book'
 require 'support/models/color'
+require 'support/models/people'
+require 'support/models/custom_attribute_builder_models'
 
 describe 'When record is updated' do
   it 'updates the changed attributes on the index' do
@@ -41,5 +43,51 @@ describe 'When record is updated' do
         jane.update(first_name: 'Jane')
       end.not_to change(People.index.tasks['results'], :count)
     end
+  end
+
+  shared_examples 'custom search blob update behavior' do |model:, reset_method:|
+    it 'evaluates custom builders once per indexing event while still updating search' do
+      TestUtil.public_send(reset_method)
+      record = model.create!(name: 'Jane')
+
+      expect(model.search('Jane')).to be_one
+      expect(model.search('Joan')).to be_empty
+
+      evaluations_before = model.search_blob_evaluations
+
+      expect do
+        record.update!(name: 'Joan')
+      end.to change { model.index.tasks['results'].count }.by(1)
+
+      expect(model.search('Jane')).to be_empty
+      expect(model.search('Joan')).to be_one
+      expect(model.search_blob_evaluations - evaluations_before).to eq(1)
+    end
+
+    it 'does not evaluate custom builders or enqueue indexing on no-op updates' do
+      TestUtil.public_send(reset_method)
+      record = model.create!(name: 'Jane')
+
+      evaluations_before = model.search_blob_evaluations
+
+      expect do
+        record.update!(name: 'Jane')
+      end.not_to(change { model.index.tasks['results'].count })
+
+      expect(model.search_blob_evaluations).to eq(evaluations_before)
+      expect(model.search('Jane')).to be_one
+    end
+  end
+
+  context 'with explicit attribute blocks' do
+    include_examples 'custom search blob update behavior',
+                     model: SearchBlobFromAttributeModel,
+                     reset_method: :reset_search_blob_from_attribute_models!
+  end
+
+  context 'with add_attribute blocks' do
+    include_examples 'custom search blob update behavior',
+                     model: SearchBlobFromAddAttributeModel,
+                     reset_method: :reset_search_blob_from_add_attribute_models!
   end
 end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -11,7 +11,7 @@ describe Meilisearch::Rails::IndexSettings do
     context 'when passed a block' do
       it 'uses the block to determine attribute\'s value' do
         m = Namespaced::Model.new(another_private_value: 2)
-        attributes = Namespaced::Model.meilisearch_settings.get_attributes(m)
+        attributes = Namespaced::Model.meilisearch_settings.build_document_attributes(m)
         expect(attributes).to include('customAttr' => 42, 'myid' => m.id)
       end
     end
@@ -109,7 +109,7 @@ describe Meilisearch::Rails::IndexSettings do
   describe 'use_serializer' do
     it 'only uses the attributes from the serializer' do
       o = SerializedDocument.new name: 'test', skip: 'skip me'
-      attributes = SerializedDocument.meilisearch_settings.get_attributes(o)
+      attributes = SerializedDocument.meilisearch_settings.build_document_attributes(o)
       expect(attributes).to eq({ name: 'test' })
     end
   end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -109,8 +109,10 @@ describe Meilisearch::Rails::IndexSettings do
   describe 'use_serializer' do
     it 'only uses the attributes from the serializer' do
       o = SerializedDocument.new name: 'test', skip: 'skip me'
-      attributes = SerializedDocument.meilisearch_settings.build_document_attributes(o)
-      expect(attributes).to eq({ name: 'test' })
+      settings = SerializedDocument.meilisearch_settings
+
+      expect(settings.build_document_attributes(o)).to eq({ name: 'test' })
+      expect(settings.indexed_field_names(o)).to eq([:name])
     end
   end
 

--- a/spec/support/models/custom_attribute_builder_models.rb
+++ b/spec/support/models/custom_attribute_builder_models.rb
@@ -1,0 +1,79 @@
+require 'support/active_record_schema'
+
+ar_schema.create_table :search_blob_from_attribute_models do |t|
+  t.string :name
+end
+
+ar_schema.create_table :search_blob_from_add_attribute_models do |t|
+  t.string :name
+end
+
+class SearchBlobFromAttributeModel < ActiveRecord::Base
+  include Meilisearch::Rails
+
+  class << self
+    attr_accessor :search_blob_evaluations
+  end
+
+  self.search_blob_evaluations = 0
+
+  meilisearch synchronous: true, index_uid: safe_index_uid('SearchBlobFromAttributeModel') do
+    attribute :search_blob do
+      self.class.search_blob_evaluations += 1
+      "#{name}--#{self.class.search_blob_evaluations}"
+    end
+
+    searchable_attributes ['search_blob']
+  end
+
+  def self.reset_evaluations!
+    self.search_blob_evaluations = 0
+  end
+
+  def will_save_change_to_search_blob?
+    will_save_change_to_name?
+  end
+end
+
+class SearchBlobFromAddAttributeModel < ActiveRecord::Base
+  include Meilisearch::Rails
+
+  class << self
+    attr_accessor :search_blob_evaluations
+  end
+
+  self.search_blob_evaluations = 0
+
+  meilisearch synchronous: true, index_uid: safe_index_uid('SearchBlobFromAddAttributeModel') do
+    attribute :name
+
+    add_attribute :search_blob do
+      self.class.search_blob_evaluations += 1
+      "#{name}--#{self.class.search_blob_evaluations}"
+    end
+
+    searchable_attributes ['name']
+  end
+
+  def self.reset_evaluations!
+    self.search_blob_evaluations = 0
+  end
+
+  def will_save_change_to_search_blob?
+    will_save_change_to_name?
+  end
+end
+
+module TestUtil
+  def self.reset_search_blob_from_attribute_models!
+    SearchBlobFromAttributeModel.clear_index!
+    SearchBlobFromAttributeModel.delete_all
+    SearchBlobFromAttributeModel.reset_evaluations!
+  end
+
+  def self.reset_search_blob_from_add_attribute_models!
+    SearchBlobFromAddAttributeModel.clear_index!
+    SearchBlobFromAddAttributeModel.delete_all
+    SearchBlobFromAddAttributeModel.reset_evaluations!
+  end
+end


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #450 

## What does this PR do?
- Fixes a performance bug in the `attribute` / `add_attribute` indexing path where custom document fields could be computed twice during updates.
- Separates “which fields are indexed” from “build the document payload”, so change detection no longer evaluates expensive custom attribute builders.

## AI disclosure

Cursor `gpt-5.4-high` and `codex-5.3-high`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Added clearer warnings when configured searchable attributes aren’t present in indexed document attributes.
  * Improved reindex/change-detection behavior to ensure custom attribute builders run only when indexed attributes actually change (no-op updates won’t trigger extra indexing).
* **Refactor**
  * Unified document attribute extraction and indexed field name computation for more consistent payload generation and dirty checking.
* **Tests**
  * Expanded settings and integration coverage for serializer and custom attribute-builder scenarios, including update/no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->