### PR TITLE
Use legacy search in pagination tests

### DIFF
--- a/spec/pagination/kaminari_spec.rb
+++ b/spec/pagination/kaminari_spec.rb
@@ -1,9 +1,13 @@
 require 'kaminari'
 require 'support/async_helper'
+require 'support/legacy_search_helper'
 require 'support/models/restaurant'
 
 describe 'Pagination with kaminari' do
+  include LegacySearchHelper
+
   before(:all) do
+    enable_meilisearch_legacy_search!
     Meilisearch::Rails.configuration[:pagination_backend] = :kaminari
     Restaurant.clear_index!
 

--- a/spec/pagination/kaminari_spec.rb
+++ b/spec/pagination/kaminari_spec.rb
@@ -22,6 +22,10 @@ describe 'Pagination with kaminari' do
     end
   end
 
+  after(:all) do
+    disable_meilisearch_legacy_search!
+  end
+
   it 'paginates' do
     first, second = Restaurant.search ''
 

--- a/spec/pagination/will_paginate_spec.rb
+++ b/spec/pagination/will_paginate_spec.rb
@@ -16,6 +16,10 @@ describe 'Pagination with will_paginate' do
     end
   end
 
+  after(:all) do
+    disable_meilisearch_legacy_search!
+  end
+
   it 'paginates with sort' do
     unpaged_hits = Movie.search ''
 

--- a/spec/pagination/will_paginate_spec.rb
+++ b/spec/pagination/will_paginate_spec.rb
@@ -1,9 +1,13 @@
 require 'will_paginate'
 require 'support/async_helper'
+require 'support/legacy_search_helper'
 require 'support/models/movie'
 
 describe 'Pagination with will_paginate' do
+  include LegacySearchHelper
+
   before(:all) do
+    enable_meilisearch_legacy_search!
     Meilisearch::Rails.configuration[:pagination_backend] = :will_paginate
     Movie.clear_index!
 

--- a/spec/support/legacy_search_helper.rb
+++ b/spec/support/legacy_search_helper.rb
@@ -14,7 +14,7 @@ module LegacySearchHelper
     uri = URI.parse("#{host.chomp('/')}#{LEGACY_SEARCH_ENDPOINT}")
     request = Net::HTTP::Patch.new(uri)
     request['Content-Type'] = 'application/json'
-    request['Authorization'] = "Bearer #{api_key}" if api_key && !api_key.empty?
+    request['Authorization'] = "Bearer #{api_key}" if api_key.present?
     request.body = { legacySearch: true }.to_json
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
@@ -23,7 +23,7 @@ module LegacySearchHelper
 
     return if response.is_a?(Net::HTTPSuccess)
 
-    raise "Failed to enable Meilisearch legacy search in tests: " \
+    raise 'Failed to enable Meilisearch legacy search in tests: ' \
           "HTTP #{response.code} #{response.message}. Response body: #{response.body}"
   rescue KeyError => e
     raise "Missing Meilisearch test configuration: #{e.message}"

--- a/spec/support/legacy_search_helper.rb
+++ b/spec/support/legacy_search_helper.rb
@@ -1,0 +1,35 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
+module LegacySearchHelper
+  LEGACY_SEARCH_ENDPOINT = '/experimental-features'.freeze
+  private_constant :LEGACY_SEARCH_ENDPOINT
+
+  def enable_meilisearch_legacy_search!
+    config = Meilisearch::Rails.configuration
+    host = config.fetch(:meilisearch_url)
+    api_key = config[:meilisearch_api_key]
+
+    uri = URI.parse("#{host.chomp('/')}#{LEGACY_SEARCH_ENDPOINT}")
+    request = Net::HTTP::Patch.new(uri)
+    request['Content-Type'] = 'application/json'
+    request['Authorization'] = "Bearer #{api_key}" if api_key && !api_key.empty?
+    request.body = { legacySearch: true }.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+
+    return if response.is_a?(Net::HTTPSuccess)
+
+    raise "Failed to enable Meilisearch legacy search in tests: " \
+          "HTTP #{response.code} #{response.message}. Response body: #{response.body}"
+  rescue KeyError => e
+    raise "Missing Meilisearch test configuration: #{e.message}"
+  rescue StandardError => e
+    raise if e.message.start_with?('Failed to enable Meilisearch legacy search in tests:')
+
+    raise "Failed to enable Meilisearch legacy search in tests: #{e.class}: #{e.message}"
+  end
+end

--- a/spec/support/legacy_search_helper.rb
+++ b/spec/support/legacy_search_helper.rb
@@ -2,20 +2,34 @@ require 'json'
 require 'net/http'
 require 'uri'
 
+# This helper is used as a workaround to enable legacy search in tests.
+# See https://github.com/meilisearch/meilisearch/issues/6482
+
 module LegacySearchHelper
   LEGACY_SEARCH_ENDPOINT = '/experimental-features'.freeze
   private_constant :LEGACY_SEARCH_ENDPOINT
 
   def enable_meilisearch_legacy_search!
+    update_meilisearch_legacy_search!(enabled: true)
+  end
+
+  def disable_meilisearch_legacy_search!
+    update_meilisearch_legacy_search!(enabled: false)
+  end
+
+  private
+
+  def update_meilisearch_legacy_search!(enabled:)
     config = Meilisearch::Rails.configuration
     host = config.fetch(:meilisearch_url)
     api_key = config[:meilisearch_api_key]
+    action = enabled ? 'enable' : 'disable'
 
     uri = URI.parse("#{host.chomp('/')}#{LEGACY_SEARCH_ENDPOINT}")
     request = Net::HTTP::Patch.new(uri)
     request['Content-Type'] = 'application/json'
     request['Authorization'] = "Bearer #{api_key}" if api_key.present?
-    request.body = { legacySearch: true }.to_json
+    request.body = { legacySearch: enabled }.to_json
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.request(request)
@@ -23,13 +37,13 @@ module LegacySearchHelper
 
     return if response.is_a?(Net::HTTPSuccess)
 
-    raise 'Failed to enable Meilisearch legacy search in tests: ' \
+    raise "Failed to #{action} Meilisearch legacy search in tests: " \
           "HTTP #{response.code} #{response.message}. Response body: #{response.body}"
   rescue KeyError => e
     raise "Missing Meilisearch test configuration: #{e.message}"
   rescue StandardError => e
-    raise if e.message.start_with?('Failed to enable Meilisearch legacy search in tests:')
+    raise if e.message.start_with?("Failed to #{action} Meilisearch legacy search in tests:")
 
-    raise "Failed to enable Meilisearch legacy search in tests: #{e.class}: #{e.message}"
+    raise "Failed to #{action} Meilisearch legacy search in tests: #{e.class}: #{e.message}"
   end
 end


### PR DESCRIPTION
# Pull Request

## Related issue
- Fixes broken pagination tests
- Workaround for https://github.com/meilisearch/meilisearch/issues/6482

## What does this PR do?
- Use the `legacySearch` experimental feature to fix the pagination tests

## AI disclosure

Cursor with `gpt-5.4-medium` and `codex-5.3-high`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated pagination test coverage (both strategies) to run with Meilisearch legacy search mode enabled, improving confidence that pagination behaves correctly under legacy search settings.
  * Added a shared test helper to enable legacy search via the Meilisearch experimental-features toggle during spec setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->